### PR TITLE
feat: Claude Codeでjustコマンドを許可なく使用可能にする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,7 +48,8 @@
       "Bash(git stash:*)",
       "Bash(git reset:*)",
       "Bash(docker compose:*)",
-      "Bash(true)"
+      "Bash(true)",
+      "Bash(just:*)"
     ],
     "deny": []
   },


### PR DESCRIPTION
## 概要
Claude Codeがjustコマンドを許可なく実行できるように設定を追加しました。

## 変更内容
- `.claude/settings.json`に`Bash(just:*)`の許可を追加

## 背景
justコマンドはプロジェクトの標準的な操作を簡潔に実行できる便利なツールですが、
Claude Codeで使用する際に毎回許可が必要でした。
この変更により、Claude Codeがjustコマンドを直接実行できるようになり、
開発効率が向上します。

## 影響範囲
- Claude Code利用時のみ影響
- justコマンドの実行が許可なく可能になる
- セキュリティ上のリスクは低い（justコマンドは定義済みのタスクのみ実行）

## テスト
- [x] `just --list`コマンドが許可なく実行できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)