### PR TITLE
Fix #455: 議事録処理状態判定ロジックの実装

### DIFF
--- a/src/domain/services/meeting_processing_status_service.py
+++ b/src/domain/services/meeting_processing_status_service.py
@@ -1,0 +1,154 @@
+"""Meeting processing status service."""
+
+from typing import TypedDict
+
+from src.domain.repositories.conversation_repository import ConversationRepository
+from src.domain.repositories.minutes_repository import MinutesRepository
+from src.domain.repositories.speaker_repository import SpeakerRepository
+
+
+class ProcessingStatus(TypedDict):
+    """Processing status of a meeting."""
+
+    has_minutes: bool
+    has_conversations: bool
+    has_speakers: bool
+    conversation_count: int
+    speaker_count: int
+
+
+class MeetingProcessingStatusService:
+    """Service for checking meeting processing status."""
+
+    def __init__(
+        self,
+        minutes_repository: MinutesRepository,
+        conversation_repository: ConversationRepository,
+        speaker_repository: SpeakerRepository,
+    ) -> None:
+        """Initialize the service with repositories."""
+        self.minutes_repository = minutes_repository
+        self.conversation_repository = conversation_repository
+        self.speaker_repository = speaker_repository
+        self._cache: dict[int, ProcessingStatus] = {}
+
+    async def has_conversations(self, meeting_id: int) -> bool:
+        """Check if a meeting has any conversations extracted.
+
+        Args:
+            meeting_id: The ID of the meeting to check
+
+        Returns:
+            True if the meeting has conversations, False otherwise
+        """
+        # Check cache first
+        if meeting_id in self._cache:
+            return self._cache[meeting_id]["has_conversations"]
+
+        # Get minutes for the meeting
+        minutes = await self.minutes_repository.get_by_meeting(meeting_id)
+        if not minutes:
+            return False
+
+        # Check if minutes has conversations
+        if minutes.id is None:
+            return False
+        conversations = await self.conversation_repository.get_by_minutes(minutes.id)
+        return len(conversations) > 0
+
+    async def has_speakers(self, meeting_id: int) -> bool:
+        """Check if a meeting has any speakers extracted.
+
+        Args:
+            meeting_id: The ID of the meeting to check
+
+        Returns:
+            True if the meeting has speakers, False otherwise
+        """
+        # Check cache first
+        if meeting_id in self._cache:
+            return self._cache[meeting_id]["has_speakers"]
+
+        # Get minutes for the meeting
+        minutes = await self.minutes_repository.get_by_meeting(meeting_id)
+        if not minutes:
+            return False
+
+        # Check if minutes has conversations with speakers
+        if minutes.id is None:
+            return False
+        conversations = await self.conversation_repository.get_by_minutes(minutes.id)
+        # Check if any conversation has a speaker_id
+        for conversation in conversations:
+            if conversation.speaker_id is not None:
+                return True
+
+        return False
+
+    async def get_processing_status(self, meeting_id: int) -> ProcessingStatus:
+        """Get comprehensive processing status for a meeting.
+
+        Args:
+            meeting_id: The ID of the meeting to check
+
+        Returns:
+            ProcessingStatus dictionary with status information
+        """
+        # Check cache first
+        if meeting_id in self._cache:
+            return self._cache[meeting_id]
+
+        # Initialize status
+        status: ProcessingStatus = {
+            "has_minutes": False,
+            "has_conversations": False,
+            "has_speakers": False,
+            "conversation_count": 0,
+            "speaker_count": 0,
+        }
+
+        # Get minutes for the meeting
+        minutes = await self.minutes_repository.get_by_meeting(meeting_id)
+        if not minutes:
+            self._cache[meeting_id] = status
+            return status
+
+        status["has_minutes"] = True
+
+        # Collect all conversations and speaker IDs
+        if minutes.id is None:
+            self._cache[meeting_id] = status
+            return status
+        conversations = await self.conversation_repository.get_by_minutes(minutes.id)
+        speaker_ids: set[int] = set()
+
+        # Collect unique speaker IDs
+        for conversation in conversations:
+            if conversation.speaker_id is not None:
+                speaker_ids.add(conversation.speaker_id)
+
+        # Update status
+        if conversations:
+            status["has_conversations"] = True
+            status["conversation_count"] = len(conversations)
+
+        if speaker_ids:
+            status["has_speakers"] = True
+            status["speaker_count"] = len(speaker_ids)
+
+        # Cache the result
+        self._cache[meeting_id] = status
+
+        return status
+
+    def clear_cache(self, meeting_id: int | None = None) -> None:
+        """Clear cached status.
+
+        Args:
+            meeting_id: The meeting ID to clear from cache.
+                       If None, clears entire cache.
+        """
+        if meeting_id is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(meeting_id, None)

--- a/tests/domain/test_meeting_processing_status_service.py
+++ b/tests/domain/test_meeting_processing_status_service.py
@@ -1,0 +1,346 @@
+"""Tests for MeetingProcessingStatusService."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.domain.entities.conversation import Conversation
+from src.domain.entities.minutes import Minutes
+from src.domain.services.meeting_processing_status_service import (
+    MeetingProcessingStatusService,
+)
+
+
+class TestMeetingProcessingStatusService:
+    """Test cases for MeetingProcessingStatusService."""
+
+    @pytest.fixture
+    def mock_minutes_repository(self):
+        """Create mock minutes repository."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_conversation_repository(self):
+        """Create mock conversation repository."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_speaker_repository(self):
+        """Create mock speaker repository."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def service(
+        self,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        mock_speaker_repository,
+    ):
+        """Create MeetingProcessingStatusService instance."""
+        return MeetingProcessingStatusService(
+            minutes_repository=mock_minutes_repository,
+            conversation_repository=mock_conversation_repository,
+            speaker_repository=mock_speaker_repository,
+        )
+
+    @pytest.fixture
+    def sample_minutes(self):
+        """Create sample minutes."""
+        return Minutes(
+            id=1,
+            meeting_id=1,
+            url="https://example.com/minutes1.pdf",
+        )
+
+    @pytest.fixture
+    def sample_conversations_with_speakers(self):
+        """Create sample conversations with speakers."""
+        return [
+            Conversation(
+                id=1,
+                comment="これは最初の発言です。",
+                sequence_number=1,
+                minutes_id=1,
+                speaker_id=10,
+                speaker_name="山田太郎",
+                chapter_number=1,
+            ),
+            Conversation(
+                id=2,
+                comment="これは二番目の発言です。",
+                sequence_number=2,
+                minutes_id=1,
+                speaker_id=11,
+                speaker_name="鈴木花子",
+                chapter_number=1,
+            ),
+        ]
+
+    @pytest.fixture
+    def sample_conversations_without_speakers(self):
+        """Create sample conversations without speakers."""
+        return [
+            Conversation(
+                id=1,
+                comment="これは最初の発言です。",
+                sequence_number=1,
+                minutes_id=1,
+                speaker_id=None,
+                speaker_name="山田太郎",
+                chapter_number=1,
+            ),
+            Conversation(
+                id=2,
+                comment="これは二番目の発言です。",
+                sequence_number=2,
+                minutes_id=1,
+                speaker_id=None,
+                speaker_name="鈴木花子",
+                chapter_number=1,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_has_conversations_true(
+        self,
+        service,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        sample_minutes,
+        sample_conversations_with_speakers,
+    ):
+        """Test has_conversations returns True when conversations exist."""
+        mock_minutes_repository.get_by_meeting.return_value = sample_minutes
+        mock_conversation_repository.get_by_minutes.return_value = (
+            sample_conversations_with_speakers
+        )
+
+        result = await service.has_conversations(meeting_id=1)
+
+        assert result is True
+        mock_minutes_repository.get_by_meeting.assert_called_once_with(1)
+        mock_conversation_repository.get_by_minutes.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_has_conversations_false_no_minutes(
+        self,
+        service,
+        mock_minutes_repository,
+    ):
+        """Test has_conversations returns False when no minutes exist."""
+        mock_minutes_repository.get_by_meeting.return_value = None
+
+        result = await service.has_conversations(meeting_id=1)
+
+        assert result is False
+        mock_minutes_repository.get_by_meeting.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_has_conversations_false_no_conversations(
+        self,
+        service,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        sample_minutes,
+    ):
+        """Test has_conversations returns False when no conversations exist."""
+        mock_minutes_repository.get_by_meeting.return_value = sample_minutes
+        mock_conversation_repository.get_by_minutes.return_value = []
+
+        result = await service.has_conversations(meeting_id=1)
+
+        assert result is False
+        mock_minutes_repository.get_by_meeting.assert_called_once_with(1)
+        mock_conversation_repository.get_by_minutes.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_has_speakers_true(
+        self,
+        service,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        sample_minutes,
+        sample_conversations_with_speakers,
+    ):
+        """Test has_speakers returns True when speakers exist."""
+        mock_minutes_repository.get_by_meeting.return_value = sample_minutes
+        mock_conversation_repository.get_by_minutes.return_value = (
+            sample_conversations_with_speakers
+        )
+
+        result = await service.has_speakers(meeting_id=1)
+
+        assert result is True
+        mock_minutes_repository.get_by_meeting.assert_called_once_with(1)
+        mock_conversation_repository.get_by_minutes.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_has_speakers_false_no_speaker_ids(
+        self,
+        service,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        sample_minutes,
+        sample_conversations_without_speakers,
+    ):
+        """Test has_speakers returns False when no speaker_ids exist."""
+        mock_minutes_repository.get_by_meeting.return_value = sample_minutes
+        mock_conversation_repository.get_by_minutes.return_value = (
+            sample_conversations_without_speakers
+        )
+
+        result = await service.has_speakers(meeting_id=1)
+
+        assert result is False
+        mock_minutes_repository.get_by_meeting.assert_called_once_with(1)
+        mock_conversation_repository.get_by_minutes.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_get_processing_status_full(
+        self,
+        service,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        sample_minutes,
+        sample_conversations_with_speakers,
+    ):
+        """Test get_processing_status with full processing."""
+        mock_minutes_repository.get_by_meeting.return_value = sample_minutes
+        mock_conversation_repository.get_by_minutes.return_value = (
+            sample_conversations_with_speakers
+        )
+
+        result = await service.get_processing_status(meeting_id=1)
+
+        assert result["has_minutes"] is True
+        assert result["has_conversations"] is True
+        assert result["has_speakers"] is True
+        assert result["conversation_count"] == 2  # 2 conversations
+        assert result["speaker_count"] == 2  # 2 unique speakers
+
+    @pytest.mark.asyncio
+    async def test_get_processing_status_no_minutes(
+        self,
+        service,
+        mock_minutes_repository,
+    ):
+        """Test get_processing_status when no minutes exist."""
+        mock_minutes_repository.get_by_meeting.return_value = None
+
+        result = await service.get_processing_status(meeting_id=1)
+
+        assert result["has_minutes"] is False
+        assert result["has_conversations"] is False
+        assert result["has_speakers"] is False
+        assert result["conversation_count"] == 0
+        assert result["speaker_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_processing_status_conversations_no_speakers(
+        self,
+        service,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        sample_minutes,
+        sample_conversations_without_speakers,
+    ):
+        """Test get_processing_status with conversations but no speakers."""
+        mock_minutes_repository.get_by_meeting.return_value = sample_minutes
+        mock_conversation_repository.get_by_minutes.return_value = (
+            sample_conversations_without_speakers
+        )
+
+        result = await service.get_processing_status(meeting_id=1)
+
+        assert result["has_minutes"] is True
+        assert result["has_conversations"] is True
+        assert result["has_speakers"] is False
+        assert result["conversation_count"] == 2  # 2 conversations
+        assert result["speaker_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cache_functionality(
+        self,
+        service,
+        mock_minutes_repository,
+        mock_conversation_repository,
+        sample_minutes,
+        sample_conversations_with_speakers,
+    ):
+        """Test cache functionality."""
+        mock_minutes_repository.get_by_meeting.return_value = sample_minutes
+        mock_conversation_repository.get_by_minutes.return_value = (
+            sample_conversations_with_speakers
+        )
+
+        # First call - should hit repositories
+        result1 = await service.get_processing_status(meeting_id=1)
+        assert mock_minutes_repository.get_by_meeting.call_count == 1
+
+        # Second call - should use cache
+        result2 = await service.get_processing_status(meeting_id=1)
+        assert mock_minutes_repository.get_by_meeting.call_count == 1  # Still 1
+
+        # Results should be the same
+        assert result1 == result2
+
+        # Clear cache
+        service.clear_cache(meeting_id=1)
+
+        # Third call - should hit repositories again
+        await service.get_processing_status(meeting_id=1)
+        assert mock_minutes_repository.get_by_meeting.call_count == 2
+
+    def test_clear_cache_all(self, service: MeetingProcessingStatusService) -> None:
+        """Test clearing entire cache."""
+        # Add some items to cache
+        service._cache[1] = {
+            "has_minutes": True,
+            "has_conversations": True,
+            "has_speakers": True,
+            "conversation_count": 10,
+            "speaker_count": 5,
+        }
+        service._cache[2] = {
+            "has_minutes": True,
+            "has_conversations": False,
+            "has_speakers": False,
+            "conversation_count": 0,
+            "speaker_count": 0,
+        }
+
+        assert len(service._cache) == 2
+
+        # Clear all cache
+        service.clear_cache()
+
+        assert len(service._cache) == 0
+
+    def test_clear_cache_specific(
+        self, service: MeetingProcessingStatusService
+    ) -> None:
+        """Test clearing specific cache entry."""
+        # Add some items to cache
+        service._cache[1] = {
+            "has_minutes": True,
+            "has_conversations": True,
+            "has_speakers": True,
+            "conversation_count": 10,
+            "speaker_count": 5,
+        }
+        service._cache[2] = {
+            "has_minutes": True,
+            "has_conversations": False,
+            "has_speakers": False,
+            "conversation_count": 0,
+            "speaker_count": 0,
+        }
+
+        assert len(service._cache) == 2
+
+        # Clear specific cache entry
+        service.clear_cache(meeting_id=1)
+
+        assert len(service._cache) == 1
+        assert 1 not in service._cache
+        assert 2 in service._cache


### PR DESCRIPTION
## 概要
議事録の各種処理（発言抽出、発言者抽出）の実行状態を、関連データの存在有無で判定するロジックを実装しました。

## 変更内容
- `MeetingProcessingStatusService`クラスを新規作成
  - `has_conversations(meeting_id)`: Meetingに紐づくConversationsの有無で発言抽出済みを判定
  - `has_speakers(meeting_id)`: Meetingに紐づくSpeakersの有無で発言者抽出済みを判定
  - `get_processing_status(meeting_id)`: 総合的な処理状態を取得
- キャッシュ機能により高速な状態取得を実現
- 包括的な単体テストを実装

## テスト結果
- ✅ 新規作成したテスト（11件）すべて成功
- ✅ 既存テストへの影響なし（監視リポジトリの既存の問題を除く）
- ✅ コード品質チェック（ruff）通過

## 関連Issue
Fixes #455

🤖 Generated with [Claude Code](https://claude.ai/code)