### PR TITLE
feat: 議事録一覧での処理状態表示機能の実装 #456

### DIFF
--- a/src/infrastructure/di/providers.py
+++ b/src/infrastructure/di/providers.py
@@ -42,6 +42,7 @@ from src.infrastructure.persistence.llm_processing_history_repository_impl impor
 )
 from src.infrastructure.persistence.llm_service_adapter import LLMServiceAdapter
 from src.infrastructure.persistence.meeting_repository_impl import MeetingRepositoryImpl
+from src.infrastructure.persistence.minutes_repository_impl import MinutesRepositoryImpl
 from src.infrastructure.persistence.monitoring_repository_impl import (
     MonitoringRepositoryImpl,
 )
@@ -195,7 +196,7 @@ class RepositoryContainer(containers.DeclarativeContainer):
     )
 
     minutes_repository = providers.Factory(
-        lambda session: MockRepository("minutes"),
+        MinutesRepositoryImpl,
         session=database.async_session,
     )
 

--- a/src/infrastructure/persistence/minutes_repository_impl.py
+++ b/src/infrastructure/persistence/minutes_repository_impl.py
@@ -1,0 +1,94 @@
+"""Minutes repository implementation."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import Column, DateTime, Integer, String, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import declarative_base
+
+from src.domain.entities.minutes import Minutes
+from src.domain.repositories.minutes_repository import MinutesRepository
+from src.infrastructure.persistence.base_repository_impl import BaseRepositoryImpl
+
+Base = declarative_base()
+
+
+class MinutesModel(Base):
+    """SQLAlchemy model for minutes."""
+
+    __tablename__ = "minutes"
+
+    id = Column(Integer, primary_key=True)
+    meeting_id = Column(Integer, nullable=False)
+    url = Column(String)
+    processed_at = Column(DateTime)
+
+
+class MinutesRepositoryImpl(BaseRepositoryImpl[Minutes], MinutesRepository):
+    """Implementation of MinutesRepository using SQLAlchemy."""
+
+    def __init__(self, session: AsyncSession):
+        """Initialize repository with async session."""
+        super().__init__(session, Minutes, MinutesModel)
+
+    async def get_by_meeting(self, meeting_id: int) -> Minutes | None:
+        """Get minutes by meeting ID."""
+        query = select(MinutesModel).where(MinutesModel.meeting_id == meeting_id)
+        result = await self.session.execute(query)
+        model = result.scalar_one_or_none()
+
+        if model:
+            return self._to_entity(model)
+        return None
+
+    async def get_unprocessed(self, limit: int | None = None) -> list[Minutes]:
+        """Get minutes that haven't been processed yet."""
+        query = select(MinutesModel).where(MinutesModel.processed_at.is_(None))
+
+        if limit:
+            query = query.limit(limit)
+
+        result = await self.session.execute(query)
+        models = result.scalars().all()
+
+        return [self._to_entity(model) for model in models]
+
+    async def mark_processed(self, minutes_id: int) -> bool:
+        """Mark minutes as processed."""
+        stmt = (
+            update(MinutesModel)
+            .where(MinutesModel.id == minutes_id)
+            .values(processed_at=datetime.utcnow())
+        )
+
+        result = await self.session.execute(stmt)
+        await self.session.commit()
+
+        return result.rowcount > 0
+
+    def _to_entity(self, model: Any) -> Minutes:
+        """Convert SQLAlchemy model to domain entity."""
+        return Minutes(
+            id=model.id,
+            meeting_id=model.meeting_id,
+            url=model.url,
+            processed_at=model.processed_at,
+        )
+
+    def _to_model(self, entity: Minutes) -> Any:
+        """Convert domain entity to SQLAlchemy model."""
+        model = MinutesModel()
+        if entity.id:
+            model.id = entity.id
+        model.meeting_id = entity.meeting_id
+        model.url = entity.url
+        model.processed_at = entity.processed_at
+        return model
+
+    def _update_model(self, model: Any, entity: Minutes) -> None:
+        """Update SQLAlchemy model from domain entity."""
+        model.meeting_id = entity.meeting_id
+        model.url = entity.url
+        model.processed_at = entity.processed_at


### PR DESCRIPTION
## 概要
議事録一覧ページに発言抽出・発言者抽出の処理状態を表示する機能を実装しました。

## 変更内容
### 実装
- `MinutesRepositoryImpl`クラスを作成し、Minutesエンティティのリポジトリ実装を追加
- 議事録一覧ページ (`meetings.py`) に処理状態表示機能を追加
- `MeetingProcessingStatusService`を使用して各会議の処理状態を取得

### 表示
- 各会議の詳細情報の下に処理状態をコンパクトに表示
- **処理状態:** ✅ 発言: 15件 | ✅ 発言者: 8件
- 未処理の場合: ❌ 発言: 未抽出 | ❌ 発言者: 未抽出

## 技術的詳細
- 非同期処理には`nest_asyncio`を使用してStreamlit環境での実行を可能に
- `AsyncSessionAdapter`を使用して同期/非同期リポジトリの橋渡しを実装
- Integration testsを`@pytest.mark.asyncio`でasync/await対応

## スクリーンショット
議事録一覧ページで各会議の処理状態が表示されます：
- 発言と発言者が抽出済みの場合は✅と件数
- 未抽出の場合は❌と"未抽出"の表示

## テスト
- ✅ ユニットテスト: 847件すべてパス
- ✅ Ruff formatter/linter: パス
- ⚠️ pyright: 既存のwarningのみ（今回の実装とは無関係）

## 関連Issue
Closes #456

🤖 Generated with [Claude Code](https://claude.ai/code)