### PR TITLE
feat: 議事録一覧に発言抽出ボタンを追加 #457

### DIFF
--- a/src/application/dtos/minutes_processing_dto.py
+++ b/src/application/dtos/minutes_processing_dto.py
@@ -1,0 +1,36 @@
+"""議事録処理関連のDTO"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class ProcessMinutesDTO:
+    """議事録処理リクエストDTO"""
+
+    meeting_id: int
+    force_reprocess: bool = False
+    pdf_url: str | None = None
+    gcs_text_uri: str | None = None
+
+
+@dataclass
+class ExtractedSpeechDTO:
+    """抽出された発言DTO"""
+
+    speaker_name: str
+    content: str
+    sequence_number: int
+
+
+@dataclass
+class MinutesProcessingResultDTO:
+    """議事録処理結果DTO"""
+
+    minutes_id: int
+    meeting_id: int
+    total_conversations: int
+    unique_speakers: int
+    processing_time_seconds: float
+    processed_at: datetime
+    errors: list[str] | None = None

--- a/src/application/usecases/execute_minutes_processing_usecase.py
+++ b/src/application/usecases/execute_minutes_processing_usecase.py
@@ -239,7 +239,7 @@ class ExecuteMinutesProcessingUseCase:
             )
 
         # MinutesProcessAgentを使用して処理
-        agent = MinutesProcessAgent(llm_service=llm_service)  # type: ignore[arg-type]
+        agent = MinutesProcessAgent(llm_service=llm_service)
 
         logger.info(f"Processing minutes (text length: {len(text)})")
 
@@ -262,7 +262,7 @@ class ExecuteMinutesProcessingUseCase:
         Returns:
             list[Conversation]: 保存された発言エンティティリスト
         """
-        conversations = []
+        conversations: list[Conversation] = []
         for idx, result in enumerate(results):
             conv = Conversation(
                 minutes_id=minutes_id,

--- a/src/application/usecases/execute_minutes_processing_usecase.py
+++ b/src/application/usecases/execute_minutes_processing_usecase.py
@@ -1,0 +1,322 @@
+"""議事録処理実行ユースケース
+
+議事録一覧画面から発言抽出処理を実行するためのユースケース。
+GCSまたはPDFから議事録テキストを取得し、MinutesProcessAgentを使用して
+発言を抽出してデータベースに保存します。
+"""
+
+import asyncio
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from src.application.dtos.minutes_processing_dto import MinutesProcessingResultDTO
+from src.common.logging import get_logger
+from src.config import config
+from src.domain.entities.conversation import Conversation
+from src.domain.entities.meeting import Meeting
+from src.domain.entities.minutes import Minutes
+from src.domain.entities.speaker import Speaker
+from src.domain.repositories.conversation_repository import ConversationRepository
+from src.domain.repositories.meeting_repository import MeetingRepository
+from src.domain.repositories.minutes_repository import MinutesRepository
+from src.domain.repositories.speaker_repository import SpeakerRepository
+from src.domain.services.speaker_domain_service import SpeakerDomainService
+from src.exceptions import APIKeyError, ProcessingError
+from src.infrastructure.external.instrumented_llm_service import (
+    InstrumentedLLMService,
+)
+from src.infrastructure.external.llm_service_factory import LLMServiceFactory
+from src.minutes_divide_processor.minutes_process_agent import MinutesProcessAgent
+from src.utils.gcs_storage import GCSStorage
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ExecuteMinutesProcessingDTO:
+    """議事録処理実行リクエストDTO"""
+
+    meeting_id: int
+    force_reprocess: bool = False
+
+
+class ExecuteMinutesProcessingUseCase:
+    """議事録処理実行ユースケース
+
+    議事録一覧画面から発言抽出処理を実行するユースケース。
+    GCSテキストまたはPDFから議事録を取得し、発言を抽出して保存します。
+    """
+
+    def __init__(
+        self,
+        meeting_repository: MeetingRepository,
+        minutes_repository: MinutesRepository,
+        conversation_repository: ConversationRepository,
+        speaker_repository: SpeakerRepository,
+        speaker_domain_service: SpeakerDomainService,
+    ):
+        """ユースケースを初期化する
+
+        Args:
+            meeting_repository: 会議リポジトリ
+            minutes_repository: 議事録リポジトリ
+            conversation_repository: 発言リポジトリ
+            speaker_repository: 発言者リポジトリ
+            speaker_domain_service: 発言者ドメインサービス
+        """
+        self.meeting_repo = meeting_repository
+        self.minutes_repo = minutes_repository
+        self.conversation_repo = conversation_repository
+        self.speaker_repo = speaker_repository
+        self.speaker_service = speaker_domain_service
+
+    async def execute(
+        self, request: ExecuteMinutesProcessingDTO
+    ) -> MinutesProcessingResultDTO:
+        """議事録処理を実行する
+
+        Args:
+            request: 処理リクエストDTO
+
+        Returns:
+            MinutesProcessingResultDTO: 処理結果
+
+        Raises:
+            ValueError: 会議が見つからない、処理可能なソースがない場合
+            APIKeyError: APIキーが設定されていない場合
+            ProcessingError: 処理中にエラーが発生した場合
+        """
+        start_time = datetime.now()
+        errors: list[str] = []
+
+        try:
+            # 会議情報を取得
+            meeting = await self.meeting_repo.get_by_id(request.meeting_id)
+            if not meeting:
+                raise ValueError(f"Meeting {request.meeting_id} not found")
+
+            # 既存の議事録をチェック
+            if meeting.id is None:
+                raise ValueError("Meeting must have an ID")
+
+            existing_minutes = await self.minutes_repo.get_by_meeting(meeting.id)
+
+            # 強制再処理でない場合、既存のConversationsをチェック
+            if existing_minutes and not request.force_reprocess:
+                if existing_minutes.id:
+                    conversations = await self.conversation_repo.get_by_minutes(
+                        existing_minutes.id
+                    )
+                    if conversations:
+                        raise ValueError(
+                            f"Meeting {meeting.id} already has conversations"
+                        )
+
+            # 議事録テキストを取得
+            extracted_text = await self._fetch_minutes_text(meeting)
+
+            # Minutes レコードを作成または取得
+            if not existing_minutes:
+                minutes = Minutes(
+                    meeting_id=meeting.id,
+                    url=meeting.url,
+                )
+                minutes = await self.minutes_repo.create(minutes)
+            else:
+                minutes = existing_minutes
+
+            # 議事録を処理
+            results = await self._process_minutes(extracted_text, meeting.id)
+
+            # Conversationsを保存
+            if minutes.id is None:
+                raise ValueError("Minutes must have an ID")
+
+            saved_conversations = await self._save_conversations(results, minutes.id)
+
+            # Speakersを抽出・作成
+            unique_speakers = await self._extract_and_create_speakers(
+                saved_conversations
+            )
+
+            # 処理完了時間を計算
+            end_time = datetime.now()
+            processing_time = (end_time - start_time).total_seconds()
+
+            return MinutesProcessingResultDTO(
+                minutes_id=minutes.id if minutes.id is not None else 0,
+                meeting_id=meeting.id if meeting.id is not None else 0,
+                total_conversations=len(saved_conversations),
+                unique_speakers=unique_speakers,
+                processing_time_seconds=processing_time,
+                processed_at=end_time,
+                errors=errors if errors else None,
+            )
+
+        except Exception as e:
+            errors.append(str(e))
+            logger.error(f"Minutes processing failed: {e}", exc_info=True)
+            raise
+
+    async def _fetch_minutes_text(self, meeting: Meeting) -> str:
+        """議事録テキストを取得する
+
+        優先順位:
+        1. GCSテキストURI
+        2. GCS PDF URI
+
+        Args:
+            meeting: 会議エンティティ
+
+        Returns:
+            str: 議事録テキスト
+
+        Raises:
+            ValueError: 処理可能なソースが見つからない場合
+        """
+        if meeting.gcs_text_uri:
+            # GCSからテキストを取得
+            try:
+                gcs_storage = GCSStorage(
+                    bucket_name=config.GCS_BUCKET_NAME,
+                    project_id=config.GCS_PROJECT_ID,
+                )
+                text = gcs_storage.download_content(meeting.gcs_text_uri)
+                if text:
+                    logger.info(
+                        f"Downloaded text from GCS ({len(text)} characters)",
+                        meeting_id=meeting.id,
+                    )
+                    return text
+            except Exception as e:
+                logger.warning(f"Failed to download from GCS: {e}")
+
+        # PDFからのテキスト抽出（将来的に実装）
+        if meeting.gcs_pdf_uri:
+            # TODO: PDF処理の実装
+            raise ValueError(
+                f"PDF processing not yet implemented for meeting {meeting.id}"
+            )
+
+        raise ValueError(f"No valid source found for meeting {meeting.id}")
+
+    async def _process_minutes(self, text: str, meeting_id: int) -> list[Any]:
+        """議事録を処理して発言を抽出する
+
+        Args:
+            text: 議事録テキスト
+            meeting_id: 会議ID
+
+        Returns:
+            list: 抽出された発言リスト
+        """
+        if not text:
+            raise ProcessingError("No text provided for processing", {"text_length": 0})
+
+        # APIキーをチェック
+        if not os.getenv("GOOGLE_API_KEY"):
+            raise APIKeyError(
+                "GOOGLE_API_KEY not set. Please configure it in your .env file",
+                {"env_var": "GOOGLE_API_KEY"},
+            )
+
+        # LLMサービスを作成
+        llm_service = LLMServiceFactory.create_gemini_service(temperature=0.0)
+
+        # InstrumentedLLMServiceの場合、履歴記録を設定
+        # 注意: 現在、asyncpgの並行操作制限のため履歴記録を無効化
+        # TODO: 履歴記録用の別セッションを適切に管理する方法を実装
+        if isinstance(llm_service, InstrumentedLLMService):
+            llm_service.set_input_reference("meeting", meeting_id)
+
+            # 履歴記録を無効化（asyncpgの並行操作エラーを回避）
+            # history_repoは設定しない
+            logger.info(
+                "InstrumentedLLMService configured without history recording",
+                meeting_id=meeting_id,
+            )
+
+        # MinutesProcessAgentを使用して処理
+        agent = MinutesProcessAgent(llm_service=llm_service)  # type: ignore[arg-type]
+
+        logger.info(f"Processing minutes (text length: {len(text)})")
+
+        # 同期的なagent.runを非同期で実行
+        loop = asyncio.get_event_loop()
+        results = await loop.run_in_executor(None, agent.run, text)
+
+        logger.info(f"Extracted {len(results)} conversations")
+        return results
+
+    async def _save_conversations(
+        self, results: list[Any], minutes_id: int
+    ) -> list[Conversation]:
+        """発言をデータベースに保存する
+
+        Args:
+            results: 抽出された発言データ
+            minutes_id: 議事録ID
+
+        Returns:
+            list[Conversation]: 保存された発言エンティティリスト
+        """
+        conversations = []
+        for idx, result in enumerate(results):
+            conv = Conversation(
+                minutes_id=minutes_id,
+                speaker_name=result.speaker,
+                comment=result.speech_content,
+                sequence_number=idx + 1,
+            )
+            conversations.append(conv)
+
+        # バルク作成
+        saved = await self.conversation_repo.bulk_create(conversations)
+        logger.info(
+            f"Saved {len(saved)} conversations to database", minutes_id=minutes_id
+        )
+        return saved
+
+    async def _extract_and_create_speakers(
+        self, conversations: list[Conversation]
+    ) -> int:
+        """発言から一意な発言者を抽出し、発言者レコードを作成する
+
+        Args:
+            conversations: 発言エンティティのリスト
+
+        Returns:
+            int: 作成された発言者数
+        """
+        speaker_names: set[tuple[str, str | None]] = set()
+
+        for conv in conversations:
+            if conv.speaker_name:
+                # 名前から政党情報を抽出
+                clean_name, party_info = self.speaker_service.extract_party_from_name(
+                    conv.speaker_name
+                )
+                speaker_names.add((clean_name, party_info))
+
+        # 発言者レコードを作成
+        created_count = 0
+        for name, party_info in speaker_names:
+            # 既存の発言者をチェック
+            existing = await self.speaker_repo.get_by_name_party_position(
+                name, party_info, None
+            )
+
+            if not existing:
+                # 新規発言者を作成
+                speaker = Speaker(
+                    name=name,
+                    political_party_name=party_info,
+                    is_politician=bool(party_info),  # 政党があれば政治家と仮定
+                )
+                await self.speaker_repo.create(speaker)
+                created_count += 1
+
+        logger.info(f"Created {created_count} new speakers")
+        return created_count

--- a/src/streamlit/utils/processing_logger.py
+++ b/src/streamlit/utils/processing_logger.py
@@ -1,0 +1,117 @@
+"""議事録処理のログ管理ユーティリティ"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+class ProcessingLogger:
+    """処理ログをファイルに保存・読み込むクラス"""
+
+    def __init__(self, base_dir: str = "/tmp/polibase_logs"):
+        """初期化
+
+        Args:
+            base_dir: ログファイルを保存するディレクトリ
+        """
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_log_file(self, meeting_id: int) -> Path:
+        """会議IDに対応するログファイルパスを取得
+
+        Args:
+            meeting_id: 会議ID
+
+        Returns:
+            ログファイルのパス
+        """
+        return self.base_dir / f"meeting_{meeting_id}.json"
+
+    def add_log(
+        self, meeting_id: int, message: str, level: str = "info", details: str = None
+    ) -> None:
+        """ログメッセージを追加
+
+        Args:
+            meeting_id: 会議ID
+            message: ログメッセージ
+            level: ログレベル (info, warning, error, success, detail)
+            details: 詳細データ（長いテキストなど、折りたたみ表示する場合）
+        """
+        log_file = self.get_log_file(meeting_id)
+
+        # 既存のログを読み込む
+        logs = self.get_logs(meeting_id)
+
+        # 新しいログエントリを追加
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        log_entry = {
+            "timestamp": timestamp,
+            "level": level.upper(),
+            "message": message,
+            "formatted": f"[{timestamp}] [{level.upper()}] {message}",
+        }
+
+        # 詳細データがある場合は追加
+        if details:
+            log_entry["details"] = details
+
+        logs.append(log_entry)
+
+        # ファイルに保存
+        with open(log_file, "w", encoding="utf-8") as f:
+            json.dump(logs, f, ensure_ascii=False, indent=2)
+
+    def get_logs(self, meeting_id: int) -> list[dict]:
+        """ログを取得
+
+        Args:
+            meeting_id: 会議ID
+
+        Returns:
+            ログエントリのリスト
+        """
+        log_file = self.get_log_file(meeting_id)
+
+        if log_file.exists():
+            with open(log_file, encoding="utf-8") as f:
+                return json.load(f)
+        return []
+
+    def clear_logs(self, meeting_id: int) -> None:
+        """ログをクリア
+
+        Args:
+            meeting_id: 会議ID
+        """
+        log_file = self.get_log_file(meeting_id)
+        if log_file.exists():
+            log_file.unlink()
+
+    def set_processing_status(self, meeting_id: int, is_processing: bool) -> None:
+        """処理状態を設定
+
+        Args:
+            meeting_id: 会議ID
+            is_processing: 処理中かどうか
+        """
+        status_file = self.base_dir / f"status_{meeting_id}.json"
+        with open(status_file, "w") as f:
+            json.dump({"is_processing": is_processing}, f)
+
+    def get_processing_status(self, meeting_id: int) -> bool:
+        """処理状態を取得
+
+        Args:
+            meeting_id: 会議ID
+
+        Returns:
+            処理中かどうか
+        """
+        status_file = self.base_dir / f"status_{meeting_id}.json"
+        if status_file.exists():
+            with open(status_file) as f:
+                data = json.load(f)
+                return data.get("is_processing", False)
+        return False

--- a/src/streamlit/utils/processing_logger.py
+++ b/src/streamlit/utils/processing_logger.py
@@ -1,6 +1,8 @@
 """議事録処理のログ管理ユーティリティ"""
 
 import json
+import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -8,12 +10,18 @@ from pathlib import Path
 class ProcessingLogger:
     """処理ログをファイルに保存・読み込むクラス"""
 
-    def __init__(self, base_dir: str = "/tmp/polibase_logs"):
+    def __init__(self, base_dir: str | None = None):
         """初期化
 
         Args:
             base_dir: ログファイルを保存するディレクトリ
+                （Noneの場合は環境変数またはtempfileを使用）
         """
+        if base_dir is None:
+            # 環境変数から取得、なければtempfileで安全なディレクトリを作成
+            base_dir = os.environ.get(
+                "POLIBASE_LOG_DIR", os.path.join(tempfile.gettempdir(), "polibase_logs")
+            )
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
@@ -29,7 +37,11 @@ class ProcessingLogger:
         return self.base_dir / f"meeting_{meeting_id}.json"
 
     def add_log(
-        self, meeting_id: int, message: str, level: str = "info", details: str = None
+        self,
+        meeting_id: int,
+        message: str,
+        level: str = "info",
+        details: str | None = None,
     ) -> None:
         """ログメッセージを追加
 
@@ -63,7 +75,7 @@ class ProcessingLogger:
         with open(log_file, "w", encoding="utf-8") as f:
             json.dump(logs, f, ensure_ascii=False, indent=2)
 
-    def get_logs(self, meeting_id: int) -> list[dict]:
+    def get_logs(self, meeting_id: int) -> list[dict[str, str]]:
         """ログを取得
 
         Args:

--- a/src/streamlit/utils/sync_minutes_processor.py
+++ b/src/streamlit/utils/sync_minutes_processor.py
@@ -1,0 +1,316 @@
+"""同期的な議事録処理実行ユーティリティ"""
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from src.common.logging import get_logger
+from src.domain.entities.conversation import Conversation
+from src.domain.entities.minutes import Minutes
+from src.domain.entities.speaker import Speaker
+from src.exceptions import APIKeyError, ProcessingError
+from src.infrastructure.external.llm_service_factory import LLMServiceFactory
+from src.infrastructure.persistence.conversation_repository_impl import (
+    ConversationRepositoryImpl as AsyncConversationRepo,
+)
+from src.infrastructure.persistence.meeting_repository_impl import (
+    MeetingRepositoryImpl as AsyncMeetingRepo,
+)
+from src.infrastructure.persistence.minutes_repository_impl import (
+    MinutesRepositoryImpl as AsyncMinutesRepo,
+)
+from src.infrastructure.persistence.repository_adapter import RepositoryAdapter
+from src.infrastructure.persistence.speaker_repository_impl import (
+    SpeakerRepositoryImpl as AsyncSpeakerRepo,
+)
+from src.minutes_divide_processor.minutes_process_agent import MinutesProcessAgent
+from src.streamlit.utils.processing_logger import ProcessingLogger
+from src.utils.gcs_storage import GCSStorage
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class SyncMinutesProcessingResult:
+    """同期処理結果"""
+
+    minutes_id: int
+    meeting_id: int
+    total_conversations: int
+    unique_speakers: int
+    processing_time_seconds: float
+    processed_at: datetime
+    errors: list[str] | None = None
+
+
+class SyncMinutesProcessor:
+    """同期的に議事録処理を実行するクラス"""
+
+    def __init__(self, meeting_id: int):
+        """初期化
+
+        Args:
+            meeting_id: 処理対象の会議ID
+        """
+        self.meeting_id = meeting_id
+        self.logger = ProcessingLogger()
+
+    def process(self) -> SyncMinutesProcessingResult:
+        """議事録処理を実行する
+
+        Returns:
+            処理結果
+        """
+        start_time = datetime.now()
+        errors = []
+
+        try:
+            self.logger.add_log(self.meeting_id, "処理を開始します", "info")
+            self.logger.add_log(
+                self.meeting_id,
+                f"会議ID {self.meeting_id} の議事録処理を実行します",
+                "info",
+            )
+
+            # 同期リポジトリを使用
+            self.logger.add_log(
+                self.meeting_id, "データベースに接続しています...", "info"
+            )
+            meeting_repo = RepositoryAdapter(AsyncMeetingRepo)
+            minutes_repo = RepositoryAdapter(AsyncMinutesRepo)
+            conversation_repo = RepositoryAdapter(AsyncConversationRepo)
+            speaker_repo = RepositoryAdapter(AsyncSpeakerRepo)
+
+            self.logger.add_log(self.meeting_id, "会議情報を取得しています...", "info")
+            # 会議情報を取得
+            meeting = meeting_repo.get_by_id(self.meeting_id)
+            if not meeting:
+                raise ValueError(f"Meeting {self.meeting_id} not found")
+
+            # 既存の議事録をチェック
+            existing_minutes = minutes_repo.get_by_meeting(self.meeting_id)
+
+            # 既存のConversationsをチェック
+            if existing_minutes and existing_minutes.id:
+                conversations = conversation_repo.get_by_minutes(existing_minutes.id)
+                if conversations:
+                    raise ValueError(
+                        f"Meeting {self.meeting_id} already has conversations"
+                    )
+
+            # 議事録テキストを取得
+            self.logger.add_log(
+                self.meeting_id, "議事録テキストを取得しています...", "info"
+            )
+            extracted_text = self._fetch_minutes_text(meeting)
+
+            # 取得したテキストの概要をログに記録
+            text_length = len(extracted_text)
+            preview_length = min(500, text_length)  # 最初の500文字まで表示
+            text_preview = extracted_text[:preview_length]
+            if text_length > preview_length:
+                text_preview += f"\n\n... (全{text_length:,}文字)"
+
+            self.logger.add_log(
+                self.meeting_id,
+                f"📄 議事録テキストを取得しました（{text_length:,}文字）",
+                "info",
+                details=text_preview,
+            )
+
+            # Minutes レコードを作成または取得
+            if not existing_minutes:
+                minutes = Minutes(
+                    meeting_id=self.meeting_id,
+                    url=meeting.url,
+                )
+                minutes = minutes_repo.create(minutes)
+            else:
+                minutes = existing_minutes
+
+            # 議事録を処理
+            self.logger.add_log(self.meeting_id, "議事録を処理しています...", "info")
+            results = self._process_minutes(extracted_text)
+
+            # 抽出結果のサマリーをログに記録
+            if results:
+                result_summary = []
+                for i, result in enumerate(results[:5], 1):  # 最初の5件を表示
+                    speaker = getattr(result, "speaker", "不明")
+                    content = getattr(result, "speech_content", "")
+                    preview = content[:100] + "..." if len(content) > 100 else content
+                    result_summary.append(f"{i}. {speaker}: {preview}")
+
+                if len(results) > 5:
+                    result_summary.append(f"\n... 他{len(results) - 5}件の発言")
+
+                self.logger.add_log(
+                    self.meeting_id,
+                    f"📝 {len(results)}件の発言を抽出しました",
+                    "info",
+                    details="\n".join(result_summary),
+                )
+
+            # Conversationsを保存
+            self.logger.add_log(self.meeting_id, "発言を保存しています...", "info")
+            saved_conversations = self._save_conversations(
+                results, minutes.id, conversation_repo
+            )
+
+            # Speakersを抽出・作成
+            self.logger.add_log(self.meeting_id, "発言者を抽出しています...", "info")
+            unique_speakers = self._extract_and_create_speakers(
+                saved_conversations, speaker_repo
+            )
+
+            # 処理完了時間を計算
+            end_time = datetime.now()
+            processing_time = (end_time - start_time).total_seconds()
+
+            self.logger.add_log(self.meeting_id, "✅ 処理が完了しました", "success")
+            self.logger.add_log(
+                self.meeting_id,
+                f"抽出された発言数: {len(saved_conversations)}件",
+                "info",
+            )
+            self.logger.add_log(
+                self.meeting_id, f"抽出された発言者数: {unique_speakers}人", "info"
+            )
+            self.logger.add_log(
+                self.meeting_id, f"処理時間: {processing_time:.2f}秒", "info"
+            )
+
+            # リポジトリを閉じる
+            meeting_repo.close()
+            minutes_repo.close()
+            conversation_repo.close()
+            speaker_repo.close()
+
+            return SyncMinutesProcessingResult(
+                minutes_id=minutes.id if minutes.id else 0,
+                meeting_id=self.meeting_id,
+                total_conversations=len(saved_conversations),
+                unique_speakers=unique_speakers,
+                processing_time_seconds=processing_time,
+                processed_at=end_time,
+                errors=errors if errors else None,
+            )
+
+        except Exception as e:
+            self.logger.add_log(
+                self.meeting_id, f"❌ エラーが発生しました: {str(e)}", "error"
+            )
+            logger.error(
+                f"Processing failed for meeting {self.meeting_id}: {e}", exc_info=True
+            )
+            raise
+
+    def _fetch_minutes_text(self, meeting: Any) -> str:
+        """議事録テキストを取得する"""
+        if meeting.gcs_text_uri:
+            try:
+                from src.config import config
+
+                gcs_storage = GCSStorage(
+                    bucket_name=config.GCS_BUCKET_NAME,
+                    project_id=config.GCS_PROJECT_ID,
+                )
+                text = gcs_storage.download_content(meeting.gcs_text_uri)
+                if text:
+                    logger.info(
+                        f"Downloaded text from GCS ({len(text)} characters)",
+                        meeting_id=meeting.id,
+                    )
+                    return text
+            except Exception as e:
+                logger.warning(f"Failed to download from GCS: {e}")
+
+        if meeting.gcs_pdf_uri:
+            raise ValueError(
+                f"PDF processing not yet implemented for meeting {meeting.id}"
+            )
+
+        raise ValueError(f"No valid source found for meeting {meeting.id}")
+
+    def _process_minutes(self, text: str) -> list[Any]:
+        """議事録を処理して発言を抽出する"""
+        if not text:
+            raise ProcessingError("No text provided for processing", {"text_length": 0})
+
+        # APIキーをチェック
+        if not os.getenv("GOOGLE_API_KEY"):
+            raise APIKeyError(
+                "GOOGLE_API_KEY not set. Please configure it in your .env file",
+                {"env_var": "GOOGLE_API_KEY"},
+            )
+
+        # LLMサービスを作成
+        llm_service = LLMServiceFactory.create_gemini_service(temperature=0.0)
+
+        # MinutesProcessAgentを使用して処理
+        agent = MinutesProcessAgent(llm_service=llm_service)
+
+        logger.info(f"Processing minutes (text length: {len(text)})")
+
+        # 同期的に実行
+        results = agent.run(text)
+
+        logger.info(f"Extracted {len(results)} conversations")
+        return results
+
+    def _save_conversations(
+        self, results: list[Any], minutes_id: int, repo: Any
+    ) -> list[Conversation]:
+        """発言をデータベースに保存する"""
+        conversations = []
+        for idx, result in enumerate(results):
+            conv = Conversation(
+                minutes_id=minutes_id,
+                speaker_name=result.speaker,
+                comment=result.speech_content,
+                sequence_number=idx + 1,
+            )
+            conversations.append(conv)
+
+        # バルク作成
+        saved = repo.bulk_create(conversations)
+        logger.info(
+            f"Saved {len(saved)} conversations to database", minutes_id=minutes_id
+        )
+        return saved
+
+    def _extract_and_create_speakers(
+        self, conversations: list[Conversation], speaker_repo: Any
+    ) -> int:
+        """発言から一意な発言者を抽出し、発言者レコードを作成する"""
+        from src.domain.services.speaker_domain_service import SpeakerDomainService
+
+        speaker_service = SpeakerDomainService()
+        speaker_names = set()
+
+        for conv in conversations:
+            if conv.speaker_name:
+                clean_name, party_info = speaker_service.extract_party_from_name(
+                    conv.speaker_name
+                )
+                speaker_names.add((clean_name, party_info))
+
+        # 発言者レコードを作成
+        created_count = 0
+        for name, party_info in speaker_names:
+            # 既存の発言者をチェック
+            existing = speaker_repo.get_by_name_party_position(name, party_info, None)
+
+            if not existing:
+                # 新規発言者を作成
+                speaker = Speaker(
+                    name=name,
+                    political_party_name=party_info,
+                    is_politician=bool(party_info),
+                )
+                speaker_repo.create(speaker)
+                created_count += 1
+
+        logger.info(f"Created {created_count} new speakers")
+        return created_count

--- a/src/streamlit/utils/sync_minutes_processor.py
+++ b/src/streamlit/utils/sync_minutes_processor.py
@@ -63,7 +63,7 @@ class SyncMinutesProcessor:
             処理結果
         """
         start_time = datetime.now()
-        errors = []
+        errors: list[str] = []
 
         try:
             self.logger.add_log(self.meeting_id, "処理を開始します", "info")
@@ -135,7 +135,7 @@ class SyncMinutesProcessor:
 
             # 抽出結果のサマリーをログに記録
             if results:
-                result_summary = []
+                result_summary: list[str] = []
                 for i, result in enumerate(results[:5], 1):  # 最初の5件を表示
                     speaker = getattr(result, "speaker", "不明")
                     content = getattr(result, "speech_content", "")
@@ -263,7 +263,7 @@ class SyncMinutesProcessor:
         self, results: list[Any], minutes_id: int, repo: Any
     ) -> list[Conversation]:
         """発言をデータベースに保存する"""
-        conversations = []
+        conversations: list[Conversation] = []
         for idx, result in enumerate(results):
             conv = Conversation(
                 minutes_id=minutes_id,
@@ -287,7 +287,7 @@ class SyncMinutesProcessor:
         from src.domain.services.speaker_domain_service import SpeakerDomainService
 
         speaker_service = SpeakerDomainService()
-        speaker_names = set()
+        speaker_names: set[tuple[str, str | None]] = set()
 
         for conv in conversations:
             if conv.speaker_name:

--- a/tests/application/usecases/test_execute_minutes_processing_usecase.py
+++ b/tests/application/usecases/test_execute_minutes_processing_usecase.py
@@ -1,0 +1,343 @@
+"""ExecuteMinutesProcessingUseCaseのテスト"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from src.application.usecases.execute_minutes_processing_usecase import (
+    ExecuteMinutesProcessingDTO,
+    ExecuteMinutesProcessingUseCase,
+)
+from src.domain.entities.conversation import Conversation
+from src.domain.entities.meeting import Meeting
+from src.domain.entities.minutes import Minutes
+from src.exceptions import APIKeyError
+
+
+@pytest.fixture
+def mock_repositories():
+    """モックリポジトリのフィクスチャ"""
+    meeting_repo = AsyncMock()
+    minutes_repo = AsyncMock()
+    conversation_repo = AsyncMock()
+    speaker_repo = AsyncMock()
+    speaker_service = MagicMock()
+
+    return {
+        "meeting_repo": meeting_repo,
+        "minutes_repo": minutes_repo,
+        "conversation_repo": conversation_repo,
+        "speaker_repo": speaker_repo,
+        "speaker_service": speaker_service,
+    }
+
+
+@pytest.fixture
+def use_case(mock_repositories):
+    """ユースケースのフィクスチャ"""
+    return ExecuteMinutesProcessingUseCase(
+        meeting_repository=mock_repositories["meeting_repo"],
+        minutes_repository=mock_repositories["minutes_repo"],
+        conversation_repository=mock_repositories["conversation_repo"],
+        speaker_repository=mock_repositories["speaker_repo"],
+        speaker_domain_service=mock_repositories["speaker_service"],
+    )
+
+
+@pytest.fixture
+def sample_meeting():
+    """サンプル会議エンティティ"""
+    return Meeting(
+        id=1,
+        conference_id=1,
+        date=datetime(2024, 1, 1),
+        url="https://example.com",
+        gcs_text_uri="gs://bucket/text.txt",
+        gcs_pdf_uri=None,
+    )
+
+
+@pytest.fixture
+def sample_minutes():
+    """サンプル議事録エンティティ"""
+    return Minutes(
+        id=1,
+        meeting_id=1,
+        url="https://example.com",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_success(
+    use_case, mock_repositories, sample_meeting, sample_minutes
+):
+    """正常に議事録処理が実行されることをテスト"""
+    # モックの設定
+    mock_repositories["meeting_repo"].get_by_id.return_value = sample_meeting
+    mock_repositories["minutes_repo"].get_by_meeting.return_value = None
+    mock_repositories["minutes_repo"].create.return_value = sample_minutes
+    mock_repositories["conversation_repo"].get_by_minutes.return_value = []
+
+    # GCSStorageをモック
+    with patch(
+        "src.application.usecases.execute_minutes_processing_usecase.GCSStorage"
+    ) as mock_gcs_patch:
+        mock_gcs = mock_gcs_patch.return_value
+        mock_gcs.download_content.return_value = "議事録テキスト"
+
+        # MinutesProcessAgentをモック
+        with patch(
+            "src.application.usecases.execute_minutes_processing_usecase.MinutesProcessAgent"
+        ) as mock_agent_patch:
+            mock_agent = mock_agent_patch.return_value
+            mock_agent.run.return_value = [
+                MagicMock(speaker="田中太郎", speech_content="発言1"),
+                MagicMock(speaker="山田花子", speech_content="発言2"),
+            ]
+
+            # LLMServiceFactoryをモック
+            with patch(
+                "src.application.usecases.execute_minutes_processing_usecase.LLMServiceFactory"
+            ) as mock_llm_factory:
+                # LLMサービスのモックを設定
+                mock_llm_service = MagicMock()
+                mock_llm_factory.create_gemini_service.return_value = mock_llm_service
+
+                # 環境変数をモック
+                with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}):
+                    # Conversationのバルク作成をモック
+                    created_conversations = [
+                        Conversation(
+                            id=1,
+                            minutes_id=1,
+                            speaker_name="田中太郎",
+                            comment="発言1",
+                            sequence_number=1,
+                        ),
+                        Conversation(
+                            id=2,
+                            minutes_id=1,
+                            speaker_name="山田花子",
+                            comment="発言2",
+                            sequence_number=2,
+                        ),
+                    ]
+                    mock_repositories[
+                        "conversation_repo"
+                    ].bulk_create.return_value = created_conversations
+
+                    # Speakerの作成をモック
+                    mock_repositories[
+                        "speaker_service"
+                    ].extract_party_from_name.side_effect = [
+                        ("田中太郎", "自民党"),
+                        ("山田花子", "立憲民主党"),
+                    ]
+                    mock_repositories[
+                        "speaker_repo"
+                    ].get_by_name_party_position.return_value = None
+                    mock_repositories["speaker_repo"].create.return_value = Mock()
+
+                    # 実行
+                    request = ExecuteMinutesProcessingDTO(meeting_id=1)
+                    result = await use_case.execute(request)
+
+                    # 検証
+                    assert result.meeting_id == 1
+                    assert result.minutes_id == 1
+                    assert result.total_conversations == 2
+                    assert result.unique_speakers == 2
+                    assert result.processing_time_seconds > 0
+                    assert result.errors is None
+
+                    # リポジトリメソッドが呼ばれたことを確認
+                    mock_repositories["meeting_repo"].get_by_id.assert_called_once_with(
+                        1
+                    )
+                    mock_repositories["minutes_repo"].create.assert_called_once()
+                    mock_repositories[
+                        "conversation_repo"
+                    ].bulk_create.assert_called_once()
+                    assert mock_repositories["speaker_repo"].create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_meeting_not_found(use_case, mock_repositories):
+    """会議が見つからない場合のエラーテスト"""
+    # モックの設定
+    mock_repositories["meeting_repo"].get_by_id.return_value = None
+
+    # 実行と検証
+    request = ExecuteMinutesProcessingDTO(meeting_id=999)
+    with pytest.raises(ValueError, match="Meeting 999 not found"):
+        await use_case.execute(request)
+
+
+@pytest.mark.asyncio
+async def test_execute_already_has_conversations(
+    use_case, mock_repositories, sample_meeting, sample_minutes
+):
+    """既にConversationsが存在する場合のエラーテスト"""
+    # モックの設定
+    mock_repositories["meeting_repo"].get_by_id.return_value = sample_meeting
+    mock_repositories["minutes_repo"].get_by_meeting.return_value = sample_minutes
+    mock_repositories["conversation_repo"].get_by_minutes.return_value = [
+        Conversation(
+            id=1,
+            minutes_id=1,
+            speaker_name="既存の発言者",
+            comment="既存の発言",
+            sequence_number=1,
+        )
+    ]
+
+    # 実行と検証
+    request = ExecuteMinutesProcessingDTO(meeting_id=1, force_reprocess=False)
+    with pytest.raises(ValueError, match="already has conversations"):
+        await use_case.execute(request)
+
+
+@pytest.mark.asyncio
+async def test_execute_force_reprocess(
+    use_case, mock_repositories, sample_meeting, sample_minutes
+):
+    """強制再処理の場合、既存のConversationsがあっても処理されることをテスト"""
+    # モックの設定
+    mock_repositories["meeting_repo"].get_by_id.return_value = sample_meeting
+    mock_repositories["minutes_repo"].get_by_meeting.return_value = sample_minutes
+    mock_repositories["conversation_repo"].get_by_minutes.return_value = [
+        Conversation(
+            id=1,
+            minutes_id=1,
+            speaker_name="既存の発言者",
+            comment="既存の発言",
+            sequence_number=1,
+        )
+    ]
+
+    # GCSStorageをモック
+    with patch(
+        "src.application.usecases.execute_minutes_processing_usecase.GCSStorage"
+    ) as mock_gcs_patch:
+        mock_gcs = mock_gcs_patch.return_value
+        mock_gcs.download_content.return_value = "議事録テキスト"
+
+        # MinutesProcessAgentをモック
+        with patch(
+            "src.application.usecases.execute_minutes_processing_usecase.MinutesProcessAgent"
+        ) as mock_agent_patch:
+            mock_agent = mock_agent_patch.return_value
+            mock_agent.run.return_value = []
+
+            # LLMServiceFactoryをモック
+            with patch(
+                "src.application.usecases.execute_minutes_processing_usecase.LLMServiceFactory"
+            ) as mock_llm_factory:
+                # LLMサービスのモックを設定
+                mock_llm_service = MagicMock()
+                mock_llm_factory.create_gemini_service.return_value = mock_llm_service
+
+                # 環境変数をモック
+                with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}):
+                    mock_repositories["conversation_repo"].bulk_create.return_value = []
+
+                    # 実行
+                    request = ExecuteMinutesProcessingDTO(
+                        meeting_id=1, force_reprocess=True
+                    )
+                    result = await use_case.execute(request)
+
+                    # 検証
+                    assert result.meeting_id == 1
+                    assert result.total_conversations == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_no_gcs_uri(use_case, mock_repositories):
+    """GCS URIがない場合のエラーテスト"""
+    # モックの設定
+    meeting_without_gcs = Meeting(
+        id=1,
+        conference_id=1,
+        date=datetime(2024, 1, 1),
+        url="https://example.com",
+        gcs_text_uri=None,
+        gcs_pdf_uri=None,
+    )
+    mock_repositories["meeting_repo"].get_by_id.return_value = meeting_without_gcs
+    mock_repositories["minutes_repo"].get_by_meeting.return_value = None
+
+    # 実行と検証
+    request = ExecuteMinutesProcessingDTO(meeting_id=1)
+    with pytest.raises(ValueError, match="No valid source found"):
+        await use_case.execute(request)
+
+
+@pytest.mark.asyncio
+async def test_execute_api_key_not_set(use_case, mock_repositories, sample_meeting):
+    """APIキーが設定されていない場合のエラーテスト"""
+    # モックの設定
+    mock_repositories["meeting_repo"].get_by_id.return_value = sample_meeting
+    mock_repositories["minutes_repo"].get_by_meeting.return_value = None
+    mock_repositories["minutes_repo"].create.return_value = Minutes(
+        id=1, meeting_id=1, url="https://example.com"
+    )
+
+    # GCSStorageをモック
+    with patch(
+        "src.application.usecases.execute_minutes_processing_usecase.GCSStorage"
+    ) as mock_gcs_patch:
+        mock_gcs = mock_gcs_patch.return_value
+        mock_gcs.download_content.return_value = "議事録テキスト"
+
+        # 環境変数をモック（APIキーなし）
+        with patch.dict("os.environ", {}, clear=True):
+            # 実行と検証
+            request = ExecuteMinutesProcessingDTO(meeting_id=1)
+            with pytest.raises(APIKeyError, match="GOOGLE_API_KEY not set"):
+                await use_case.execute(request)
+
+
+@pytest.mark.asyncio
+async def test_extract_and_create_speakers(use_case, mock_repositories):
+    """発言者の抽出と作成のテスト"""
+    # テストデータ
+    conversations = [
+        Conversation(
+            id=1,
+            minutes_id=1,
+            speaker_name="田中太郎（自民党）",
+            comment="発言1",
+            sequence_number=1,
+        ),
+        Conversation(
+            id=2,
+            minutes_id=1,
+            speaker_name="山田花子",
+            comment="発言2",
+            sequence_number=2,
+        ),
+        Conversation(
+            id=3,
+            minutes_id=1,
+            speaker_name="田中太郎（自民党）",  # 重複
+            comment="発言3",
+            sequence_number=3,
+        ),
+    ]
+
+    # モックの設定
+    mock_repositories["speaker_service"].extract_party_from_name.side_effect = [
+        ("田中太郎", "自民党"),
+        ("山田花子", None),
+        ("田中太郎", "自民党"),  # 重複
+    ]
+    mock_repositories["speaker_repo"].get_by_name_party_position.return_value = None
+
+    # 実行
+    created_count = await use_case._extract_and_create_speakers(conversations)
+
+    # 検証
+    assert created_count == 2  # 重複を除いた数
+    assert mock_repositories["speaker_repo"].create.call_count == 2


### PR DESCRIPTION
## 概要
議事録一覧ページに発言抽出処理を実行するボタンを追加し、リアルタイムでログを表示する機能を実装しました。

Closes #457

## 変更内容

### 新機能
- 議事録一覧の各行に「発言抽出」ボタンを追加
- 処理ログをリアルタイムで表示（折りたたみ可能）
- 処理中の状態管理と適切なUIフィードバック

### UI/UX改善
- 処理中は「処理中...」と表示し、ボタンを無効化
- 既に発言が抽出済みの場合は「抽出済」と表示
- GCSテキストURIがない場合は「データなし」と表示
- エラー時は適切にエラーメッセージを表示
- ログの詳細データ（議事録テキスト、抽出結果など）を折りたたみ表示

### 技術的詳細

#### 新規実装
1. **ExecuteMinutesProcessingUseCase**
   - 議事録処理の非同期ユースケース
   - クリーンアーキテクチャに準拠した実装

2. **ProcessingLogger**
   - ファイルベースのログ管理システム
   - スレッド間でのセッションステート問題を解決

3. **SyncMinutesProcessor**
   - 同期的な議事録処理実行クラス
   - イベントループの競合を回避

4. **テストケース**
   - ExecuteMinutesProcessingUseCaseの包括的なテスト
   - 7つのテストケースすべてが成功

#### 技術的課題の解決
- **スレッド間通信**: Streamlitのセッションステートがバックグラウンドスレッドから更新できない問題をファイルベースのログシステムで解決
- **イベントループ競合**: asyncpgの並行操作制限を同期処理で回避
- **リアルタイム更新**: ポーリングによるログ表示の自動更新

## 既知の問題
以下の問題を発見しましたが、別Issueで対応予定です：

1. **Issue #463**: LLM履歴記録機能の並行実行対応
   - asyncpgの制限により一時的に無効化
   - 独立したデータベース接続プールの実装が必要

2. **Issue #464**: 議事録処理で発言が抽出されない問題
   - 出席者リストの誤判定により議事録全体がスキップされる
   - MinutesProcessAgentの判定ロジックの修正が必要

## テスト結果
```bash
# ユニットテスト
docker compose exec polibase uv run pytest tests/application/usecases/test_execute_minutes_processing_usecase.py -v
# 7 passed

# 手動テスト
- 議事録一覧ページで発言抽出ボタンが表示されることを確認 ✅
- 処理中の状態遷移が正しく動作することを確認 ✅
- ログがリアルタイムで表示されることを確認 ✅
- 折りたたみ表示が動作することを確認 ✅
```

## スクリーンショット
※議事録一覧ページに追加された発言抽出ボタンとログ表示機能

## デプロイメント注意事項
- `/tmp/polibase_logs/`ディレクトリが作成されることを確認
- 既存のデータベーススキーマとの互換性あり（マイグレーション不要）

🤖 Generated with [Claude Code](https://claude.ai/code)