### PR TITLE
fix: 議事録処理で発言が抽出されない問題を修正 #464

### DIFF
--- a/src/minutes_divide_processor/minutes_divider.py
+++ b/src/minutes_divide_processor/minutes_divider.py
@@ -267,25 +267,6 @@ class MinutesDivider:
         # 出席者リストパターンをチェック
         section_text = section_string.section_string
 
-        # 出席者リストや参加者一覧を示すパターン
-        attendance_patterns = [
-            r"◯出席委員",
-            r"◯欠席委員",
-            r"◯委員会説明員",
-            r"◯配付資料",
-            r"◯要求資料",
-            r"◯特記事項",
-            r"出席者一覧",
-            r"参加者リスト",
-            r"委員長\s+[^\n]+議員\n副委員長\s+[^\n]+議員",  # 役職者リストパターン
-        ]
-
-        # セクションが出席者リストである場合はスキップ
-        for pattern in attendance_patterns:
-            if re.search(pattern, section_text):
-                print(f"出席者リストセクションをスキップ: {section_text[:50]}...")
-                return SpeakerAndSpeechContentList(speaker_and_speech_content_list=[])
-
         # 実際の発言が含まれているかチェック（○や◆などの発言者記号があるか）
         speech_indicators = [
             r"○[^○\n]+（[^）]+）",
@@ -296,6 +277,29 @@ class MinutesDivider:
         has_speech = any(
             re.search(pattern, section_text) for pattern in speech_indicators
         )
+
+        # 出席者リストや参加者一覧を示すパターン
+        attendance_patterns = [
+            r"◯出席委員",
+            r"◯欠席委員",
+            r"◯委員会説明員",
+            r"◯配付資料",
+            r"◯要求資料",
+            r"◯特記事項",
+            r"出席者一覧",
+            r"参加者リスト",
+        ]
+
+        # セクションが出席者リストのみで発言が含まれていない場合はスキップ
+        has_attendance = any(
+            re.search(pattern, section_text) for pattern in attendance_patterns
+        )
+
+        if has_attendance and not has_speech:
+            print(
+                f"出席者リストセクション（発言なし）をスキップ: {section_text[:50]}..."
+            )
+            return SpeakerAndSpeechContentList(speaker_and_speech_content_list=[])
 
         # 発言者記号がない場合で、短いテキストの場合はスキップ
         if not has_speech and len(section_text) < 100:


### PR DESCRIPTION
## 概要
議事録処理で発言が含まれているにも関わらず、0件として抽出される問題を修正しました。

## 問題の原因
`minutes_divider.py`の出席者リスト判定パターンに含まれていた以下のパターンが問題でした：
```python
r"委員長\s+[^\n]+議員\n副委員長\s+[^\n]+議員"
```

このパターンは委員長・副委員長の名前が含まれるテキスト全体をマッチしてしまい、実際の発言部分も含めて「出席者リスト」として誤判定していました。

## 修正内容
1. **問題のパターンを削除**: 広すぎる役職者リストパターンを削除
2. **判定ロジックの改善**: 
   - 先に発言の有無をチェック
   - 出席者リストパターンが含まれていても、発言がある場合は処理を継続
   - 出席者リストのみで発言がない場合のみスキップ

## テスト結果
- ✅ 出席者リストと発言が混在するテキスト → 正しく処理される
- ✅ 出席者リストのみのテキスト → スキップされる
- ✅ 発言のみのテキスト → 正しく処理される
- ✅ 既存のテストがすべてパス

## 動作確認
```python
# テストスクリプトで動作確認済み
# - 議長（西村義直）の発言が正しく抽出されることを確認
# - 出席者リスト部分と発言部分が適切に区別されることを確認
```

Fixes #464

🤖 Generated with [Claude Code](https://claude.ai/code)