### PR TITLE
fix: 会議一覧タブで編集ボタンを押すとエラーになる問題を修正 #475

### DIFF
--- a/src/streamlit/pages/conferences.py
+++ b/src/streamlit/pages/conferences.py
@@ -236,9 +236,9 @@ def manage_conferences():
                                     st.markdown("---")
 
                                     # 開催主体の選択
-                                    governing_bodies = conf_repo.get_governing_bodies()
+                                    governing_bodies = gb_repo.get_all()
                                     gb_options = ["なし"] + [
-                                        f"{gb['name']} ({gb['type']})"
+                                        f"{gb.name} ({gb.type})"
                                         for gb in governing_bodies
                                     ]
 
@@ -246,7 +246,7 @@ def manage_conferences():
                                     current_gb_index = 0
                                     if conf.get("governing_body_id"):
                                         for i, gb in enumerate(governing_bodies):
-                                            if gb["id"] == conf["governing_body_id"]:
+                                            if gb.id == conf["governing_body_id"]:
                                                 current_gb_index = (
                                                     i + 1
                                                 )  # "なし"の分を加算


### PR DESCRIPTION
## 概要
会議一覧タブで編集ボタンを押すとエラーになる問題を修正しました。

## 問題の原因
`ConferenceRepositoryImpl`には`get_governing_bodies()`メソッドが存在しないのに、`conferences.py`の239行目で呼び出していました。

## 修正内容
- `conf_repo.get_governing_bodies()`を`gb_repo.get_all()`に変更
- `gb_repo.get_all()`はエンティティオブジェクトのリストを返すので、dictionary形式のアクセス(`gb["name"]`)をオブジェクト形式のアクセス(`gb.name`)に変更
- 同様に`gb["id"]`を`gb.id`に、`gb["type"]`を`gb.type`に変更

## テスト結果
✅ ruff format: パス
✅ ruff lint: パス  
✅ pyright: 警告はあるがエラーなし
✅ pytest: 関連するテストがパス

Fixes #475

🤖 Generated with [Claude Code](https://claude.ai/code)