### PR TITLE
fix: 会議一覧ページで発言抽出ボタンを押したときにunexpected keyword argumentエラーが出る問題を修正 #477

### DIFF
--- a/src/application/usecases/execute_minutes_processing_usecase.py
+++ b/src/application/usecases/execute_minutes_processing_usecase.py
@@ -27,7 +27,7 @@ from src.exceptions import APIKeyError, ProcessingError
 from src.infrastructure.external.instrumented_llm_service import (
     InstrumentedLLMService,
 )
-from src.infrastructure.external.llm_service_factory import LLMServiceFactory
+from src.services.llm_factory import LLMServiceFactory
 from src.minutes_divide_processor.minutes_process_agent import MinutesProcessAgent
 from src.utils.gcs_storage import GCSStorage
 

--- a/src/application/usecases/execute_minutes_processing_usecase.py
+++ b/src/application/usecases/execute_minutes_processing_usecase.py
@@ -27,8 +27,8 @@ from src.exceptions import APIKeyError, ProcessingError
 from src.infrastructure.external.instrumented_llm_service import (
     InstrumentedLLMService,
 )
-from src.services.llm_factory import LLMServiceFactory
 from src.minutes_divide_processor.minutes_process_agent import MinutesProcessAgent
+from src.services.llm_factory import LLMServiceFactory
 from src.utils.gcs_storage import GCSStorage
 
 logger = get_logger(__name__)

--- a/src/application/usecases/execute_minutes_processing_usecase.py
+++ b/src/application/usecases/execute_minutes_processing_usecase.py
@@ -223,7 +223,8 @@ class ExecuteMinutesProcessingUseCase:
             )
 
         # LLMサービスを作成
-        llm_service = LLMServiceFactory.create_gemini_service(temperature=0.0)
+        factory = LLMServiceFactory()
+        llm_service = factory.create_fast(temperature=0.0)
 
         # InstrumentedLLMServiceの場合、履歴記録を設定
         # 注意: 現在、asyncpgの並行操作制限のため履歴記録を無効化

--- a/src/streamlit/utils/sync_minutes_processor.py
+++ b/src/streamlit/utils/sync_minutes_processor.py
@@ -10,7 +10,6 @@ from src.domain.entities.conversation import Conversation
 from src.domain.entities.minutes import Minutes
 from src.domain.entities.speaker import Speaker
 from src.exceptions import APIKeyError, ProcessingError
-from src.services.llm_factory import LLMServiceFactory
 from src.infrastructure.persistence.conversation_repository_impl import (
     ConversationRepositoryImpl as AsyncConversationRepo,
 )
@@ -25,6 +24,7 @@ from src.infrastructure.persistence.speaker_repository_impl import (
     SpeakerRepositoryImpl as AsyncSpeakerRepo,
 )
 from src.minutes_divide_processor.minutes_process_agent import MinutesProcessAgent
+from src.services.llm_factory import LLMServiceFactory
 from src.streamlit.utils.processing_logger import ProcessingLogger
 from src.utils.gcs_storage import GCSStorage
 

--- a/src/streamlit/utils/sync_minutes_processor.py
+++ b/src/streamlit/utils/sync_minutes_processor.py
@@ -10,7 +10,7 @@ from src.domain.entities.conversation import Conversation
 from src.domain.entities.minutes import Minutes
 from src.domain.entities.speaker import Speaker
 from src.exceptions import APIKeyError, ProcessingError
-from src.infrastructure.external.llm_service_factory import LLMServiceFactory
+from src.services.llm_factory import LLMServiceFactory
 from src.infrastructure.persistence.conversation_repository_impl import (
     ConversationRepositoryImpl as AsyncConversationRepo,
 )
@@ -264,7 +264,6 @@ class SyncMinutesProcessor:
         """議事録テキストから出席者マッピングを抽出する"""
         try:
             from src.minutes_divide_processor.minutes_divider import MinutesDivider
-            from src.services.llm_factory import LLMServiceFactory
 
             # LLMサービスを作成
             factory = LLMServiceFactory()

--- a/src/streamlit/utils/sync_minutes_processor.py
+++ b/src/streamlit/utils/sync_minutes_processor.py
@@ -267,7 +267,8 @@ class SyncMinutesProcessor:
             from src.services.llm_factory import LLMServiceFactory
 
             # LLMサービスを作成
-            llm_service = LLMServiceFactory.create_gemini_service(temperature=0.0)
+            factory = LLMServiceFactory()
+            llm_service = factory.create_fast(temperature=0.0)
 
             # MinutesDividerを作成
             divider = MinutesDivider(llm_service=llm_service)
@@ -313,7 +314,8 @@ class SyncMinutesProcessor:
             )
 
         # LLMサービスを作成
-        llm_service = LLMServiceFactory.create_gemini_service(temperature=0.0)
+        factory = LLMServiceFactory()
+        llm_service = factory.create_fast(temperature=0.0)
 
         # MinutesProcessAgentを使用して処理
         agent = MinutesProcessAgent(llm_service=llm_service)


### PR DESCRIPTION
## 概要
会議一覧ページで発言抽出ボタンを押したときに`unexpected keyword argument 'temperature'`のエラーが発生する問題を修正しました。

## 問題の詳細
`LLMServiceFactory.create_gemini_service()`メソッドは引数を受け取らない仕様になっていましたが、コード内で`temperature=0.0`を渡そうとしていたためエラーが発生していました。

## 修正内容
- `LLMServiceFactory`のインスタンスを作成してから`create_fast(temperature=0.0)`を呼ぶように変更
- 影響箇所：
  - `src/streamlit/utils/sync_minutes_processor.py` (2箇所)
  - `src/application/usecases/execute_minutes_processing_usecase.py` (1箇所)

## テスト結果
- ✅ 単体テスト: 449 passed, 10 skipped
- ✅ コードフォーマット: ruff format/check passed
- ⚠️ pyright: 既存の型アノテーション問題のみ（本修正とは無関係）

## 関連Issue
Fixes #477

🤖 Generated with Claude Code