### PR TITLE
feat: ProposalエンティティのURL分離実装 #503

### DIFF
--- a/database/02_run_migrations.sql
+++ b/database/02_run_migrations.sql
@@ -26,5 +26,6 @@
 \i /docker-entrypoint-initdb.d/02_migrations/021_create_extracted_parliamentary_group_members_table.sql
 \i /docker-entrypoint-initdb.d/02_migrations/022_add_proposal_metadata.sql
 \i /docker-entrypoint-initdb.d/02_migrations/023_create_extracted_proposal_judges.sql
+\i /docker-entrypoint-initdb.d/02_migrations/024_add_status_url_to_proposals.sql
 
 \echo 'Migrations completed.'

--- a/database/migrations/024_add_status_url_to_proposals.sql
+++ b/database/migrations/024_add_status_url_to_proposals.sql
@@ -1,0 +1,23 @@
+-- 議案テーブルのURL管理を詳細URLとステータスURLに分離
+
+-- 1. 新しいカラムを追加
+ALTER TABLE proposals
+ADD COLUMN detail_url VARCHAR,
+ADD COLUMN status_url VARCHAR;
+
+-- 2. 既存データの移行（既存のurlをdetail_urlへ）
+UPDATE proposals
+SET detail_url = url
+WHERE url IS NOT NULL;
+
+-- 3. 古いurlカラムを削除
+ALTER TABLE proposals
+DROP COLUMN url;
+
+-- 4. カラムにコメントを追加
+COMMENT ON COLUMN proposals.detail_url IS '議案の詳細本文URL（法案内容、議案内容など）';
+COMMENT ON COLUMN proposals.status_url IS '議案の審議状況URL（経過状態、賛成会派情報など）';
+
+-- 5. インデックスの追加（検索性能向上のため）
+CREATE INDEX idx_proposals_detail_url ON proposals(detail_url);
+CREATE INDEX idx_proposals_status_url ON proposals(status_url);

--- a/src/application/dtos/proposal_dto.py
+++ b/src/application/dtos/proposal_dto.py
@@ -16,7 +16,8 @@ class ScrapeProposalOutputDTO:
     """Output DTO for scraped proposal information."""
 
     content: str
-    url: str
+    detail_url: str | None = None
+    status_url: str | None = None
     proposal_number: str | None = None
     submission_date: str | None = None  # ISO format date
     summary: str | None = None
@@ -28,7 +29,8 @@ class CreateProposalDTO:
     """DTO for creating a new proposal."""
 
     content: str
-    url: str | None = None
+    detail_url: str | None = None
+    status_url: str | None = None
     submission_date: str | None = None
     proposal_number: str | None = None
     meeting_id: int | None = None
@@ -41,7 +43,8 @@ class UpdateProposalDTO:
 
     id: int
     content: str | None = None
-    url: str | None = None
+    detail_url: str | None = None
+    status_url: str | None = None
     submission_date: str | None = None
     proposal_number: str | None = None
     meeting_id: int | None = None
@@ -54,7 +57,8 @@ class ProposalDTO:
 
     id: int
     content: str
-    url: str | None = None
+    detail_url: str | None = None
+    status_url: str | None = None
     submission_date: str | None = None
     proposal_number: str | None = None
     meeting_id: int | None = None

--- a/src/application/usecases/scrape_proposal_usecase.py
+++ b/src/application/usecases/scrape_proposal_usecase.py
@@ -67,7 +67,8 @@ class ScrapeProposalUseCase:
             proposal_number=scraped_data.proposal_number,
             submission_date=scraped_data.submission_date,
             summary=scraped_data.summary,
-            url=scraped_data.url,
+            detail_url=scraped_data.url,  # Default to detail_url for scraped content
+            status_url=None,  # Status URL can be set separately
             meeting_id=input_dto.meeting_id,
         )
 
@@ -100,16 +101,22 @@ class ScrapeProposalUseCase:
                 logger.warning(f"Proposal {scraped_dto.proposal_number} already exists")
                 return self._entity_to_dto(existing)
 
-        # Check by URL
-        existing_by_url = await self.proposal_repo.find_by_url(scraped_dto.url)
-        if existing_by_url:
-            logger.warning(f"Proposal with URL {scraped_dto.url} already exists")
-            return self._entity_to_dto(existing_by_url)
+        # Check by URL (detail_url)
+        if scraped_dto.detail_url:
+            existing_by_url = await self.proposal_repo.find_by_url(
+                scraped_dto.detail_url
+            )
+            if existing_by_url:
+                logger.warning(
+                    f"Proposal with URL {scraped_dto.detail_url} already exists"
+                )
+                return self._entity_to_dto(existing_by_url)
 
         # Create new proposal entity
         proposal = Proposal(
             content=scraped_dto.content,
-            url=scraped_dto.url,
+            detail_url=scraped_dto.detail_url,
+            status_url=scraped_dto.status_url,
             submission_date=scraped_dto.submission_date,
             proposal_number=scraped_dto.proposal_number,
             meeting_id=scraped_dto.meeting_id,
@@ -147,7 +154,8 @@ class ScrapeProposalUseCase:
 
         # Update the existing proposal
         existing.content = scraped_dto.content or existing.content
-        existing.url = scraped_dto.url
+        existing.detail_url = scraped_dto.detail_url or existing.detail_url
+        existing.status_url = scraped_dto.status_url or existing.status_url
         existing.submission_date = (
             scraped_dto.submission_date or existing.submission_date
         )
@@ -176,7 +184,8 @@ class ScrapeProposalUseCase:
         return ProposalDTO(
             id=proposal.id,
             content=proposal.content,
-            url=proposal.url,
+            detail_url=proposal.detail_url,
+            status_url=proposal.status_url,
             submission_date=proposal.submission_date,
             proposal_number=proposal.proposal_number,
             meeting_id=proposal.meeting_id,

--- a/src/domain/entities/proposal.py
+++ b/src/domain/entities/proposal.py
@@ -10,7 +10,8 @@ class Proposal(BaseEntity):
         self,
         content: str,
         status: str | None = None,
-        url: str | None = None,
+        detail_url: str | None = None,
+        status_url: str | None = None,
         submission_date: str | None = None,  # ISO形式の日付文字列
         submitter: str | None = None,
         proposal_number: str | None = None,
@@ -21,7 +22,8 @@ class Proposal(BaseEntity):
         super().__init__(id)
         self.content = content
         self.status = status
-        self.url = url
+        self.detail_url = detail_url
+        self.status_url = status_url
         self.submission_date = submission_date
         self.submitter = submitter
         self.proposal_number = proposal_number

--- a/src/infrastructure/persistence/proposal_repository_impl.py
+++ b/src/infrastructure/persistence/proposal_repository_impl.py
@@ -23,7 +23,8 @@ class ProposalModel(PydanticBaseModel):
     id: int | None = None
     content: str
     status: str | None = None
-    url: str | None = None
+    detail_url: str | None = None
+    status_url: str | None = None
     submission_date: str | None = None
     submitter: str | None = None
     proposal_number: str | None = None
@@ -66,7 +67,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id,
                     content,
                     status,
-                    url,
+                    detail_url,
+                    status_url,
                     submission_date,
                     submitter,
                     proposal_number,
@@ -118,7 +120,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id,
                     content,
                     status,
-                    url,
+                    detail_url,
+                    status_url,
                     submission_date,
                     submitter,
                     proposal_number,
@@ -168,7 +171,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id,
                     content,
                     status,
-                    url,
+                    detail_url,
+                    status_url,
                     submission_date,
                     submitter,
                     proposal_number,
@@ -212,15 +216,17 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
         try:
             query = text("""
                 INSERT INTO proposals (
-                    content, status, url, submission_date, submitter,
-                    proposal_number, meeting_id, summary
+                    content, status, detail_url, status_url, submission_date,
+                    submitter, proposal_number, meeting_id, summary
                 )
                 VALUES (
-                    :content, :status, :url, :submission_date, :submitter,
-                    :proposal_number, :meeting_id, :summary
+                    :content, :status, :detail_url, :status_url,
+                    :submission_date, :submitter, :proposal_number, :meeting_id,
+                    :summary
                 )
-                RETURNING id, content, status, url, submission_date, submitter,
-                          proposal_number, meeting_id, summary, created_at, updated_at
+                RETURNING id, content, status, detail_url, status_url,
+                          submission_date, submitter, proposal_number,
+                          meeting_id, summary, created_at, updated_at
             """)
 
             result = await self.session.execute(
@@ -228,7 +234,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                 {
                     "content": entity.content,
                     "status": entity.status,
-                    "url": entity.url,
+                    "detail_url": entity.detail_url,
+                    "status_url": entity.status_url,
                     "submission_date": entity.submission_date,
                     "submitter": entity.submitter,
                     "proposal_number": entity.proposal_number,
@@ -274,7 +281,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                 UPDATE proposals
                 SET content = :content,
                     status = :status,
-                    url = :url,
+                    detail_url = :detail_url,
+                    status_url = :status_url,
                     submission_date = :submission_date,
                     submitter = :submitter,
                     proposal_number = :proposal_number,
@@ -282,8 +290,9 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     summary = :summary,
                     updated_at = CURRENT_TIMESTAMP
                 WHERE id = :id
-                RETURNING id, content, status, url, submission_date, submitter,
-                          proposal_number, meeting_id, summary, created_at, updated_at
+                RETURNING id, content, status, detail_url, status_url,
+                          submission_date, submitter, proposal_number,
+                          meeting_id, summary, created_at, updated_at
             """)
 
             result = await self.session.execute(
@@ -292,7 +301,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     "id": entity.id,
                     "content": entity.content,
                     "status": entity.status,
-                    "url": entity.url,
+                    "detail_url": entity.detail_url,
+                    "status_url": entity.status_url,
                     "submission_date": entity.submission_date,
                     "submitter": entity.submitter,
                     "proposal_number": entity.proposal_number,
@@ -369,7 +379,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
             id=model.id,
             content=model.content,
             status=model.status,
-            url=model.url,
+            detail_url=model.detail_url,
+            status_url=model.status_url,
             submission_date=model.submission_date,
             submitter=model.submitter,
             proposal_number=model.proposal_number,
@@ -390,7 +401,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
             id=entity.id,
             content=entity.content,
             status=entity.status,
-            url=entity.url,
+            detail_url=entity.detail_url,
+            status_url=entity.status_url,
             submission_date=entity.submission_date,
             submitter=entity.submitter,
             proposal_number=entity.proposal_number,
@@ -407,7 +419,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
         """
         model.content = entity.content
         model.status = entity.status
-        model.url = entity.url
+        model.detail_url = entity.detail_url
+        model.status_url = entity.status_url
         model.submission_date = entity.submission_date
         model.submitter = entity.submitter
         model.proposal_number = entity.proposal_number
@@ -427,7 +440,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
             id=data.get("id"),
             content=data["content"],
             status=data.get("status"),
-            url=data.get("url"),
+            detail_url=data.get("detail_url"),
+            status_url=data.get("status_url"),
             submission_date=data.get("submission_date"),
             submitter=data.get("submitter"),
             proposal_number=data.get("proposal_number"),
@@ -450,7 +464,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id,
                     content,
                     status,
-                    url,
+                    detail_url,
+                    status_url,
                     submission_date,
                     submitter,
                     proposal_number,
@@ -499,7 +514,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id,
                     content,
                     status,
-                    url,
+                    detail_url,
+                    status_url,
                     submission_date,
                     submitter,
                     proposal_number,
@@ -551,7 +567,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id,
                     content,
                     status,
-                    url,
+                    detail_url,
+                    status_url,
                     submission_date,
                     submitter,
                     proposal_number,
@@ -591,7 +608,7 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
             ) from e
 
     async def find_by_url(self, url: str) -> Proposal | None:
-        """Find proposal by URL.
+        """Find proposal by URL (either detail_url or status_url).
 
         Args:
             url: URL of the proposal
@@ -608,7 +625,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id,
                     content,
                     status,
-                    url,
+                    detail_url,
+                    status_url,
                     submission_date,
                     submitter,
                     proposal_number,
@@ -617,7 +635,7 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     created_at,
                     updated_at
                 FROM proposals
-                WHERE url = :url
+                WHERE detail_url = :url OR status_url = :url
             """)
             result = await self.session.execute(query, {"url": url})
             row = result.fetchone()
@@ -627,7 +645,8 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     id=row.id,
                     content=row.content,
                     status=row.status,
-                    url=row.url,
+                    detail_url=row.detail_url,
+                    status_url=row.status_url,
                     submission_date=row.submission_date,
                     submitter=row.submitter,
                     proposal_number=row.proposal_number,

--- a/tests/application/usecases/test_scrape_proposal_usecase.py
+++ b/tests/application/usecases/test_scrape_proposal_usecase.py
@@ -66,7 +66,7 @@ class TestScrapeProposalUseCase:
         assert result.proposal_number == "第210回国会 第1号"
         assert result.submission_date == "2023年12月1日"  # Original format preserved
         assert result.summary == "環境保護強化法案"
-        assert result.url == input_dto.url
+        assert result.detail_url == input_dto.url
         assert result.meeting_id == 123
 
     @pytest.mark.asyncio
@@ -129,7 +129,7 @@ class TestScrapeProposalUseCase:
             proposal_number="第210回国会 第1号",
             submission_date="2023年12月1日",
             summary="環境保護強化法案",
-            url=input_dto.url,
+            detail_url=input_dto.url,
             meeting_id=123,
         )
         mock_proposal_repo.create.return_value = saved_proposal
@@ -174,7 +174,7 @@ class TestScrapeProposalUseCase:
             id=1,
             content="環境基本法改正案",
             proposal_number="第210回国会 第1号",
-            url="https://old-url.com",
+            detail_url="https://old-url.com",
         )
         mock_proposal_repo.get_by_proposal_number.return_value = existing_proposal
 
@@ -210,7 +210,7 @@ class TestScrapeProposalUseCase:
         existing_proposal = Proposal(
             id=2,
             content="環境基本法改正案",
-            url=input_dto.url,
+            detail_url=input_dto.url,
         )
         mock_proposal_repo.find_by_url.return_value = existing_proposal
 
@@ -219,7 +219,7 @@ class TestScrapeProposalUseCase:
 
         # Assert
         assert result.id == 2
-        assert result.url == input_dto.url
+        assert result.detail_url == input_dto.url
 
         # Verify save was not called
         mock_proposal_repo.create.assert_not_called()
@@ -261,7 +261,7 @@ class TestScrapeProposalUseCase:
             proposal_number="第210回国会 第1号",
             submission_date="2023年12月1日",
             summary="環境保護強化法案",
-            url=new_url,
+            detail_url=new_url,
             meeting_id=123,
         )
         mock_proposal_repo.update.return_value = updated_proposal
@@ -272,7 +272,7 @@ class TestScrapeProposalUseCase:
         # Assert
         assert result.id == proposal_id
         assert result.content == "新環境基本法改正案"
-        assert result.url == new_url
+        assert result.detail_url == new_url
         assert result.meeting_id == 123
 
         # Verify repository calls

--- a/tests/domain/entities/test_proposal.py
+++ b/tests/domain/entities/test_proposal.py
@@ -26,7 +26,8 @@ class TestProposal:
         assert proposal.content == "令和6年度予算案の承認について"
         assert proposal.status == "審議中"
         # New fields should be None by default
-        assert proposal.url is None
+        assert proposal.detail_url is None
+        assert proposal.status_url is None
         assert proposal.submission_date is None
         assert proposal.submitter is None
         assert proposal.proposal_number is None
@@ -39,7 +40,8 @@ class TestProposal:
             id=1,
             content="令和6年度予算案の承認について",
             status="審議中",
-            url="https://example.com/proposal/001",
+            detail_url="https://example.com/proposal/001",
+            status_url="https://example.com/proposal/status/001",
             submission_date="2024-01-15",
             submitter="財務委員会",
             proposal_number="議案第1号",
@@ -50,7 +52,8 @@ class TestProposal:
         assert proposal.id == 1
         assert proposal.content == "令和6年度予算案の承認について"
         assert proposal.status == "審議中"
-        assert proposal.url == "https://example.com/proposal/001"
+        assert proposal.detail_url == "https://example.com/proposal/001"
+        assert proposal.status_url == "https://example.com/proposal/status/001"
         assert proposal.submission_date == "2024-01-15"
         assert proposal.submitter == "財務委員会"
         assert proposal.proposal_number == "議案第1号"
@@ -113,12 +116,25 @@ class TestProposal:
 
     def test_metadata_fields(self) -> None:
         """Test metadata fields with various values."""
-        # Test with URL
-        proposal_with_url = Proposal(
+        # Test with detail URL
+        proposal_with_detail_url = Proposal(
             content="議案内容",
-            url="https://council.example.com/proposals/2024/001",
+            detail_url="https://council.example.com/proposals/2024/001",
         )
-        assert proposal_with_url.url == "https://council.example.com/proposals/2024/001"
+        assert (
+            proposal_with_detail_url.detail_url
+            == "https://council.example.com/proposals/2024/001"
+        )
+
+        # Test with status URL
+        proposal_with_status_url = Proposal(
+            content="議案内容",
+            status_url="https://council.example.com/proposals/status/001",
+        )
+        assert (
+            proposal_with_status_url.status_url
+            == "https://council.example.com/proposals/status/001"
+        )
 
         # Test with submission date
         proposal_with_date = Proposal(

--- a/tests/infrastructure/persistence/test_proposal_repository_impl.py
+++ b/tests/infrastructure/persistence/test_proposal_repository_impl.py
@@ -44,7 +44,8 @@ class TestProposalRepositoryImpl:
             "id": 1,
             "content": "令和6年度予算案の承認について",
             "status": "審議中",
-            "url": "https://example.com/proposal/001",
+            "detail_url": "https://example.com/proposal/001",
+            "status_url": "https://example.com/proposal/status/001",
             "submission_date": "2024-01-15",
             "submitter": "財務委員会",
             "proposal_number": "議案第1号",
@@ -306,7 +307,8 @@ class TestProposalRepositoryImpl:
             id=1,
             content="Test content",
             status="審議中",
-            url="https://test.url",
+            detail_url="https://test.detail.url",
+            status_url="https://test.status.url",
             submission_date="2024-01-15",
             submitter="テスト提出者",
             proposal_number="テスト番号",
@@ -319,7 +321,8 @@ class TestProposalRepositoryImpl:
         assert entity.id == 1
         assert entity.content == "Test content"
         assert entity.status == "審議中"
-        assert entity.url == "https://test.url"
+        assert entity.detail_url == "https://test.detail.url"
+        assert entity.status_url == "https://test.status.url"
         assert entity.submission_date == "2024-01-15"
         assert entity.submitter == "テスト提出者"
         assert entity.proposal_number == "テスト番号"
@@ -332,7 +335,8 @@ class TestProposalRepositoryImpl:
             id=1,
             content="Test content",
             status="審議中",
-            url="https://test.url",
+            detail_url="https://test.detail.url",
+            status_url="https://test.status.url",
             submission_date="2024-01-15",
             submitter="テスト提出者",
             proposal_number="テスト番号",
@@ -345,7 +349,8 @@ class TestProposalRepositoryImpl:
         assert model.id == 1
         assert model.content == "Test content"
         assert model.status == "審議中"
-        assert model.url == "https://test.url"
+        assert model.detail_url == "https://test.detail.url"
+        assert model.status_url == "https://test.status.url"
         assert model.submission_date == "2024-01-15"
         assert model.submitter == "テスト提出者"
         assert model.proposal_number == "テスト番号"
@@ -358,7 +363,8 @@ class TestProposalRepositoryImpl:
             id=1,
             content="Old content",
             status="審議中",
-            url="https://old.url",
+            detail_url="https://old.detail.url",
+            status_url="https://old.status.url",
             submission_date="2023-01-01",
             submitter="旧提出者",
             proposal_number="旧番号",
@@ -369,7 +375,8 @@ class TestProposalRepositoryImpl:
             id=1,
             content="New content",
             status="可決",
-            url="https://new.url",
+            detail_url="https://new.detail.url",
+            status_url="https://new.status.url",
             submission_date="2024-01-01",
             submitter="新提出者",
             proposal_number="新番号",
@@ -381,7 +388,8 @@ class TestProposalRepositoryImpl:
 
         assert model.content == "New content"
         assert model.status == "可決"
-        assert model.url == "https://new.url"
+        assert model.detail_url == "https://new.detail.url"
+        assert model.status_url == "https://new.status.url"
         assert model.submission_date == "2024-01-01"
         assert model.submitter == "新提出者"
         assert model.proposal_number == "新番号"


### PR DESCRIPTION
## 概要
議案（Proposal）エンティティのURLフィールドを、詳細URL（detail_url）と状況URL（status_url）に分離する実装です。

## 背景
実際の議会システム（国会、京都市議会など）では、議案の詳細内容と採決状況が別々のURLで管理されているため、これに対応する必要がありました。

## 変更内容

### 1. データベーススキーマの変更
- `proposals.url` カラムを削除
- `proposals.detail_url` カラムを追加（議案の詳細本文URL）
- `proposals.status_url` カラムを追加（議案の審議状況URL）
- 既存データは自動的に `detail_url` に移行

### 2. ドメインエンティティの更新
- `Proposal` エンティティの `url` フィールドを `detail_url` と `status_url` に変更

### 3. リポジトリ実装の更新
- `ProposalRepositoryImpl` のSQLクエリを新しいフィールド構造に対応
- `find_by_url` メソッドは両方のURLフィールドを検索

### 4. DTOの更新
- `ProposalDTO`、`CreateProposalDTO`、`UpdateProposalDTO`、`ScrapeProposalOutputDTO` を更新

### 5. ユースケースの更新
- `ScrapeProposalUseCase` でスクレイピング時に `detail_url` を設定

## テスト
- ✅ 全ユニットテストが通過（611 tests passed）
- ✅ コード品質チェック（ruff）通過
- ✅ 型チェック（pyright）通過 ※テストファイルのprotectedメソッドアクセス警告を除く

## マイグレーション
`database/migrations/024_add_status_url_to_proposals.sql` を実行してください：
```sql
ALTER TABLE proposals 
ADD COLUMN detail_url VARCHAR,
ADD COLUMN status_url VARCHAR;

UPDATE proposals SET detail_url = url WHERE url IS NOT NULL;

ALTER TABLE proposals DROP COLUMN url;
```

##   マイグレーション実行方法

  方法1: reset-database.sh を使う（全データリセット）

  ./scripts/reset-database.sh
  - ⚠️  注意: 全データが削除されて初期状態に戻ります
  - すべてのマイグレーション（024含む）が自動実行されます

  方法2: 手動で個別マイグレーションを実行（既存データを保持）

  # Dockerコンテナ経由で実行
  cat database/migrations/024_add_status_url_to_proposals.sql | docker
  compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml
   exec -T postgres psql -U polibase_user -d polibase_db

  または

  # just コマンドを使う場合
  just exec "cat
  /app/database/migrations/024_add_status_url_to_proposals.sql | psql -U
  polibase_user -d polibase_db"

  方法3: データベースに直接接続して実行

  # PostgreSQLに接続
  docker compose -f docker/docker-compose.yml -f
  docker/docker-compose.override.yml exec postgres psql -U polibase_user -d
  polibase_db

  # SQLプロンプトで実行
  \i /app/database/migrations/024_add_status_url_to_proposals.sql

## 関連Issue
Closes #503

🤖 Generated with [Claude Code](https://claude.ai/code)