### PR TITLE
feat: 議案管理UI（Streamlit）の実装

### DIFF
--- a/src/infrastructure/persistence/extracted_proposal_judge_repository_impl.py
+++ b/src/infrastructure/persistence/extracted_proposal_judge_repository_impl.py
@@ -45,6 +45,26 @@ class ExtractedProposalJudgeRepositoryImpl(
     def __init__(self, session: AsyncSession):
         super().__init__(session, ExtractedProposalJudge, ExtractedProposalJudgeModel)
 
+    async def get_all(
+        self, limit: int | None = None, offset: int | None = None
+    ) -> list[ExtractedProposalJudge]:
+        """Get all extracted proposal judges with optional pagination."""
+        query_str = "SELECT * FROM extracted_proposal_judges ORDER BY id"
+        params: dict[str, Any] = {}
+
+        if limit:
+            query_str += " LIMIT :limit"
+            params["limit"] = limit
+        if offset:
+            query_str += " OFFSET :offset"
+            params["offset"] = offset
+
+        query = text(query_str)
+        result = await self.session.execute(query, params)
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
     async def get_pending_judges(
         self, proposal_id: int | None = None
     ) -> list[ExtractedProposalJudge]:

--- a/src/infrastructure/persistence/proposal_repository_impl.py
+++ b/src/infrastructure/persistence/proposal_repository_impl.py
@@ -229,6 +229,16 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                           meeting_id, summary, created_at, updated_at
             """)
 
+            # Convert submission_date from ISO string to datetime if needed
+            submission_date_value = None
+            if entity.submission_date:
+                if isinstance(entity.submission_date, str):
+                    submission_date_value = datetime.fromisoformat(
+                        entity.submission_date
+                    )
+                else:
+                    submission_date_value = entity.submission_date
+
             result = await self.session.execute(
                 query,
                 {
@@ -236,7 +246,7 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     "status": entity.status,
                     "detail_url": entity.detail_url,
                     "status_url": entity.status_url,
-                    "submission_date": entity.submission_date,
+                    "submission_date": submission_date_value,
                     "submitter": entity.submitter,
                     "proposal_number": entity.proposal_number,
                     "meeting_id": entity.meeting_id,
@@ -295,6 +305,16 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                           meeting_id, summary, created_at, updated_at
             """)
 
+            # Convert submission_date from ISO string to datetime if needed
+            submission_date_value = None
+            if entity.submission_date:
+                if isinstance(entity.submission_date, str):
+                    submission_date_value = datetime.fromisoformat(
+                        entity.submission_date
+                    )
+                else:
+                    submission_date_value = entity.submission_date
+
             result = await self.session.execute(
                 query,
                 {
@@ -303,7 +323,7 @@ class ProposalRepositoryImpl(BaseRepositoryImpl[Proposal], ProposalRepository):
                     "status": entity.status,
                     "detail_url": entity.detail_url,
                     "status_url": entity.status_url,
-                    "submission_date": entity.submission_date,
+                    "submission_date": submission_date_value,
                     "submitter": entity.submitter,
                     "proposal_number": entity.proposal_number,
                     "meeting_id": entity.meeting_id,

--- a/src/streamlit/app.py
+++ b/src/streamlit/app.py
@@ -31,6 +31,7 @@ from src.streamlit.pages import (  # noqa: E402
     manage_parliamentary_groups,
     manage_political_parties,
     manage_politicians,
+    manage_proposals,
 )
 from src.streamlit.utils import init_session_state  # noqa: E402
 
@@ -78,6 +79,9 @@ def home_page():
 
         ### 💬 [発言レコード一覧](/conversations)
         議事録分割で生成された発言レコード一覧
+
+        ### 📋 [議案管理](/proposals)
+        議案と賛否情報の3段階管理
         """)
 
 
@@ -127,6 +131,12 @@ def main():
             title="発言レコード一覧",
             url_path="conversations",
             icon="💬",
+        ),
+        st.Page(
+            manage_proposals,
+            title="議案管理",
+            url_path="proposals",
+            icon="📋",
         ),
     ]
 

--- a/src/streamlit/pages/__init__.py
+++ b/src/streamlit/pages/__init__.py
@@ -10,6 +10,7 @@ from .parliamentary_groups import manage_parliamentary_groups
 from .political_parties import manage_political_parties
 from .politicians import manage_politicians
 from .processes import execute_processes
+from .proposals import manage_proposals
 
 __all__ = [
     "manage_conferences",
@@ -21,5 +22,6 @@ __all__ = [
     "manage_parliamentary_groups",
     "manage_politicians",
     "manage_political_parties",
+    "manage_proposals",
     "execute_processes",
 ]

--- a/src/streamlit/pages/proposals.py
+++ b/src/streamlit/pages/proposals.py
@@ -497,11 +497,7 @@ def manage_proposal_judges_tab():
                     "政治家",
                     options=[p.id for p in politicians],
                     format_func=lambda x: next(
-                        (
-                            f"{p.name} ({p.party or '無所属'})"
-                            for p in politicians
-                            if p.id == x
-                        ),
+                        (f"{p.name}" for p in politicians if p.id == x),
                         "",
                     ),
                     key="new_judge_politician",

--- a/src/streamlit/pages/proposals.py
+++ b/src/streamlit/pages/proposals.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-from datetime import datetime
 from typing import cast
 
 import pandas as pd
@@ -140,7 +139,7 @@ def manage_proposals_tab():
                             detail_url=detail_url,
                             status_url=status_url if status_url else None,
                             meeting_id=meeting_id,
-                            submission_date=datetime.now().isoformat(),
+                            submission_date=None,  # LLMで後から抽出される
                         )
                         created = proposal_repo.create(new_proposal)
                         if created:

--- a/src/streamlit/pages/proposals.py
+++ b/src/streamlit/pages/proposals.py
@@ -78,24 +78,27 @@ def manage_proposals_tab():
         st.info(
             "会議体を選択し、議案URLを登録してください。議案情報は後でLLMで自動抽出されます。"
         )
-        with st.form(key="new_proposal_form"):
-            # 会議体選択
-            conferences = conference_repo.get_all()
-            conference_id = st.selectbox(
-                "会議体",
-                options=[c.id for c in conferences],
-                format_func=lambda x: next(
-                    (f"{c.name}" for c in conferences if c.id == x),
-                    "不明",
-                ),
-                key="new_proposal_conference",
-                help="この議案を審議する会議体を選択してください",
-            )
 
-            # 会議体に関連する会議を取得して選択
-            selected_conference_meetings = [
-                m for m in meetings if m.conference_id == conference_id
-            ]
+        # 会議体選択（フォームの外）
+        conferences = conference_repo.get_all()
+        conference_id = st.selectbox(
+            "会議体",
+            options=[c.id for c in conferences],
+            format_func=lambda x: next(
+                (f"{c.name}" for c in conferences if c.id == x),
+                "不明",
+            ),
+            key="new_proposal_conference",
+            help="この議案を審議する会議体を選択してください",
+        )
+
+        # 選択された会議体に関連する会議を取得
+        selected_conference_meetings = [
+            m for m in meetings if m.conference_id == conference_id
+        ]
+
+        with st.form(key="new_proposal_form"):
+            # 会議選択（フィルタリングされた会議）
             if selected_conference_meetings:
                 meeting_id = st.selectbox(
                     "会議（オプション）",

--- a/src/streamlit/pages/proposals.py
+++ b/src/streamlit/pages/proposals.py
@@ -1,0 +1,626 @@
+"""議案管理UI（Streamlit）."""
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import cast
+
+import pandas as pd
+
+import streamlit as st
+from src.application.dtos.proposal_dto import ScrapeProposalInputDTO
+from src.application.usecases.scrape_proposal_usecase import ScrapeProposalUseCase
+from src.domain.entities.proposal import Proposal
+from src.domain.entities.proposal_judge import ProposalJudge
+from src.infrastructure.external.proposal_scraper_service import ProposalScraperService
+from src.infrastructure.persistence.extracted_proposal_judge_repository_impl import (
+    ExtractedProposalJudgeRepositoryImpl,
+)
+from src.infrastructure.persistence.meeting_repository_impl import MeetingRepositoryImpl
+from src.infrastructure.persistence.politician_repository_impl import (
+    PoliticianRepositoryImpl,
+)
+from src.infrastructure.persistence.proposal_judge_repository_impl import (
+    ProposalJudgeRepositoryImpl,
+)
+from src.infrastructure.persistence.proposal_repository_impl import (
+    ProposalRepositoryImpl,
+)
+from src.infrastructure.persistence.repository_adapter import RepositoryAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def manage_proposals():
+    """議案管理メインページ."""
+    st.title("議案管理")
+
+    # タブ作成
+    tab1, tab2, tab3 = st.tabs(
+        [
+            "議案管理 (Proposals)",
+            "LLM抽出結果 (ExtractedProposalJudges)",
+            "確定賛否情報 (ProposalJudges)",
+        ]
+    )
+
+    with tab1:
+        manage_proposals_tab()
+
+    with tab2:
+        manage_extracted_judges_tab()
+
+    with tab3:
+        manage_proposal_judges_tab()
+
+
+def manage_proposals_tab():
+    """議案管理タブ."""
+    st.subheader("議案一覧")
+
+    # リポジトリ初期化
+    proposal_repo = RepositoryAdapter(ProposalRepositoryImpl)
+    meeting_repo = RepositoryAdapter(MeetingRepositoryImpl)
+
+    # フィルター
+    meetings = meeting_repo.get_all()
+    meeting_options = ["すべて"] + [f"{m.date} - ID:{m.id}" for m in meetings if m.date]
+    selected_meeting = st.selectbox(
+        "会議でフィルタリング", meeting_options, key="filter_meeting"
+    )
+
+    # 新規議案登録フォーム
+    with st.expander("新規議案登録", expanded=False):
+        with st.form(key="new_proposal_form"):
+            col1, col2 = st.columns(2)
+            with col1:
+                content = st.text_area("議案内容", key="new_proposal_content")
+                proposal_number = st.text_input("議案番号", key="new_proposal_number")
+                submitter = st.text_input("提出者", key="new_proposal_submitter")
+
+            with col2:
+                meeting_id = st.selectbox(
+                    "会議",
+                    options=[None] + [m.id for m in meetings],
+                    format_func=lambda x: "未選択" if x is None else f"ID: {x}",
+                    key="new_proposal_meeting_id",
+                )
+                detail_url = st.text_input("詳細URL", key="new_proposal_detail_url")
+                status_url = st.text_input("状態URL", key="new_proposal_status_url")
+
+            summary = st.text_area("概要", key="new_proposal_summary")
+
+            if st.form_submit_button("登録"):
+                if content:
+                    try:
+                        new_proposal = Proposal(
+                            content=content,
+                            proposal_number=proposal_number
+                            if proposal_number
+                            else None,
+                            submitter=submitter if submitter else None,
+                            meeting_id=meeting_id,
+                            detail_url=detail_url if detail_url else None,
+                            status_url=status_url if status_url else None,
+                            summary=summary if summary else None,
+                            submission_date=datetime.now().isoformat(),
+                        )
+                        created = proposal_repo.create(new_proposal)
+                        if created:
+                            st.success("議案を登録しました")
+                            st.rerun()
+                        else:
+                            st.error("議案の登録に失敗しました")
+                    except Exception as e:
+                        st.error(f"エラーが発生しました: {str(e)}")
+                else:
+                    st.error("議案内容は必須です")
+
+    # 議案一覧取得
+    proposals = proposal_repo.get_all()
+
+    # フィルタリング
+    if selected_meeting != "すべて":
+        meeting_id = int(selected_meeting.split("ID:")[1])
+        proposals = [p for p in proposals if p.meeting_id == meeting_id]
+
+    if proposals:
+        # DataFrameに変換
+        df_data = []
+        for p in proposals:
+            df_data.append(
+                {
+                    "id": p.id,
+                    "proposal_number": p.proposal_number or "番号なし",
+                    "content": p.content[:50] + "..."
+                    if len(p.content) > 50
+                    else p.content,
+                    "submitter": p.submitter or "不明",
+                    "status": p.status or "未処理",
+                    "meeting_id": p.meeting_id,
+                    "detail_url": p.detail_url,
+                    "status_url": p.status_url,
+                }
+            )
+        df = pd.DataFrame(df_data)
+
+        # 各レコードの表示と操作ボタン
+        for _idx, row in df.iterrows():
+            col1, col2, col3, col4 = st.columns([4, 1, 1, 1])
+
+            with col1:
+                st.markdown(f"**{row['proposal_number']}**: {row['content']}")
+                st.caption(f"提出者: {row['submitter']} | 状態: {row['status']}")
+                if row["detail_url"]:
+                    st.caption(f"詳細URL: {row['detail_url']}")
+
+            with col2:
+                if st.button("編集", key=f"edit_proposal_{row['id']}"):
+                    st.session_state.edit_proposal_id = row["id"]
+                    st.rerun()
+
+            with col3:
+                # スクレイピング実行ボタン
+                detail_url = cast(str, row["detail_url"])
+                status_url = cast(str | None, row["status_url"])
+                if detail_url and not status_url:
+                    if st.button("スクレイピング", key=f"scrape_proposal_{row['id']}"):
+                        with st.spinner("スクレイピング中..."):
+                            try:
+                                # スクレイピング実行
+                                scraper_service = ProposalScraperService()
+                                # 型の問題を回避するために直接インスタンスを作成
+                                from src.config.database import get_db_session
+                                from src.infrastructure.persistence import (
+                                    async_session_adapter as asa,
+                                )
+
+                                sync_session = get_db_session()
+                                async_session = asa.AsyncSessionAdapter(sync_session)
+                                proposal_repo_async = ProposalRepositoryImpl(
+                                    async_session
+                                )
+
+                                use_case = ScrapeProposalUseCase(
+                                    proposal_repository=proposal_repo_async,
+                                    proposal_scraper_service=scraper_service,
+                                )
+                                # 入力DTOを作成
+                                input_dto = ScrapeProposalInputDTO(
+                                    url=detail_url, meeting_id=None
+                                )
+                                # 非同期処理を同期的に実行
+                                loop = asyncio.new_event_loop()
+                                asyncio.set_event_loop(loop)
+                                result = loop.run_until_complete(
+                                    use_case.execute(input_dto)
+                                )
+                                if result:
+                                    st.success("スクレイピングが完了しました")
+                                    st.rerun()
+                                else:
+                                    st.error("スクレイピングに失敗しました")
+                            except Exception as e:
+                                st.error(f"エラー: {str(e)}")
+                elif status_url:
+                    st.button(
+                        "スクレイピング済",
+                        key=f"scrape_proposal_{row['id']}",
+                        disabled=True,
+                    )
+                else:
+                    st.button(
+                        "URLなし", key=f"scrape_proposal_{row['id']}", disabled=True
+                    )
+
+            with col4:
+                if st.button("削除", key=f"delete_proposal_{row['id']}"):
+                    if proposal_repo.delete(row["id"]):
+                        st.success("議案を削除しました")
+                        st.rerun()
+                    else:
+                        st.error("議案の削除に失敗しました")
+
+            st.divider()
+
+        # 編集モード
+        if "edit_proposal_id" in st.session_state:
+            edit_proposal(st.session_state.edit_proposal_id)
+
+    else:
+        st.info("議案が登録されていません")
+
+    proposal_repo.close()
+    meeting_repo.close()
+
+
+def edit_proposal(proposal_id: int):
+    """議案編集フォーム."""
+    st.subheader("議案編集")
+
+    proposal_repo = RepositoryAdapter(ProposalRepositoryImpl)
+    proposal = proposal_repo.get_by_id(proposal_id)
+
+    if proposal:
+        with st.form(key=f"edit_proposal_form_{proposal_id}"):
+            content = st.text_area("議案内容", value=proposal.content)
+            proposal_number = st.text_input(
+                "議案番号", value=proposal.proposal_number or ""
+            )
+            submitter = st.text_input("提出者", value=proposal.submitter or "")
+            status = st.text_input("状態", value=proposal.status or "")
+            summary = st.text_area("概要", value=proposal.summary or "")
+
+            col1, col2 = st.columns(2)
+            with col1:
+                if st.form_submit_button("更新"):
+                    proposal.content = content
+                    proposal.proposal_number = (
+                        proposal_number if proposal_number else None
+                    )
+                    proposal.submitter = submitter if submitter else None
+                    proposal.status = status if status else None
+                    proposal.summary = summary if summary else None
+
+                    if proposal_repo.update(proposal):
+                        st.success("議案を更新しました")
+                        del st.session_state.edit_proposal_id
+                        st.rerun()
+                    else:
+                        st.error("更新に失敗しました")
+
+            with col2:
+                if st.form_submit_button("キャンセル"):
+                    del st.session_state.edit_proposal_id
+                    st.rerun()
+
+    proposal_repo.close()
+
+
+def manage_extracted_judges_tab():
+    """LLM抽出結果管理タブ."""
+    st.subheader("LLM抽出結果一覧")
+
+    # リポジトリ初期化
+    extracted_repo = RepositoryAdapter(ExtractedProposalJudgeRepositoryImpl)
+    proposal_repo = RepositoryAdapter(ProposalRepositoryImpl)
+    politician_repo = RepositoryAdapter(PoliticianRepositoryImpl)
+
+    # フィルター
+    col1, col2 = st.columns(2)
+    with col1:
+        proposals = proposal_repo.get_all()
+        proposal_options = ["すべて"] + [
+            f"{p.proposal_number or f'ID:{p.id}'}: {p.content[:30]}..."
+            for p in proposals
+        ]
+        selected_proposal = st.selectbox(
+            "議案でフィルタリング", proposal_options, key="filter_extracted_proposal"
+        )
+
+    with col2:
+        status_options = ["すべて", "pending", "matched", "needs_review", "no_match"]
+        selected_status = st.selectbox(
+            "状態でフィルタリング", status_options, key="filter_extracted_status"
+        )
+
+    # 抽出結果一覧取得
+    extracted_judges = extracted_repo.get_all()
+
+    # フィルタリング
+    if selected_proposal != "すべて":
+        proposal_id = proposals[proposal_options.index(selected_proposal) - 1].id
+        extracted_judges = [e for e in extracted_judges if e.proposal_id == proposal_id]
+
+    if selected_status != "すべて":
+        extracted_judges = [
+            e for e in extracted_judges if e.matching_status == selected_status
+        ]
+
+    if extracted_judges:
+        # 各レコードの表示と操作ボタン
+        for judge in extracted_judges:
+            col1, col2, col3, col4, col5 = st.columns([3, 1, 1, 1, 1])
+
+            with col1:
+                # 政治家名または議員団名を表示
+                name = (
+                    judge.extracted_politician_name
+                    or judge.extracted_parliamentary_group_name
+                    or "不明"
+                )
+                st.markdown(f"**{name}**")
+                judgment = judge.extracted_judgment or "不明"
+                st.caption(f"賛否: {judgment} | 状態: {judge.matching_status}")
+                if judge.matching_confidence:
+                    st.caption(f"信頼度: {judge.matching_confidence:.2%}")
+                if judge.extracted_party_name:
+                    st.caption(f"政党: {judge.extracted_party_name}")
+
+            with col2:
+                if st.button("編集", key=f"edit_extracted_{judge.id}"):
+                    st.session_state.edit_extracted_id = judge.id
+                    st.rerun()
+
+            with col3:
+                # マッチング実行ボタン
+                if judge.matching_status == "pending":
+                    if st.button("マッチング", key=f"match_extracted_{judge.id}"):
+                        with st.spinner("マッチング中..."):
+                            # TODO: マッチング処理の実装
+                            st.info("マッチング機能は開発中です")
+                else:
+                    st.button(
+                        "マッチング済", key=f"match_extracted_{judge.id}", disabled=True
+                    )
+
+            with col4:
+                # ProposalJudgeへの変換ボタン
+                if judge.matching_status == "matched" and judge.matched_politician_id:
+                    if st.button("確定", key=f"confirm_extracted_{judge.id}"):
+                        try:
+                            # ProposalJudgeに変換
+                            proposal_judge_repo = RepositoryAdapter(
+                                ProposalJudgeRepositoryImpl
+                            )
+                            new_judge = ProposalJudge(
+                                proposal_id=judge.proposal_id,
+                                politician_id=judge.matched_politician_id,
+                                approve=judge.extracted_judgment,
+                            )
+                            if proposal_judge_repo.create(new_judge):
+                                # 変換済みのExtractedJudgeを削除
+                                extracted_repo.delete(judge.id)
+                                st.success("賛否情報を確定しました")
+                                st.rerun()
+                            else:
+                                st.error("確定に失敗しました")
+                            proposal_judge_repo.close()
+                        except Exception as e:
+                            st.error(f"エラー: {str(e)}")
+                else:
+                    st.button(
+                        "確定", key=f"confirm_extracted_{judge.id}", disabled=True
+                    )
+
+            with col5:
+                if st.button("削除", key=f"delete_extracted_{judge.id}"):
+                    if extracted_repo.delete(judge.id):
+                        st.success("抽出結果を削除しました")
+                        st.rerun()
+                    else:
+                        st.error("削除に失敗しました")
+
+            st.divider()
+
+        # 編集モード
+        if "edit_extracted_id" in st.session_state:
+            edit_extracted_judge(st.session_state.edit_extracted_id)
+
+    else:
+        st.info("抽出結果がありません")
+
+    extracted_repo.close()
+    proposal_repo.close()
+    politician_repo.close()
+
+
+def edit_extracted_judge(extracted_id: int):
+    """抽出結果編集フォーム."""
+    st.subheader("抽出結果編集")
+
+    extracted_repo = RepositoryAdapter(ExtractedProposalJudgeRepositoryImpl)
+    extracted = extracted_repo.get_by_id(extracted_id)
+
+    if extracted:
+        with st.form(key=f"edit_extracted_form_{extracted_id}"):
+            politician_name = st.text_input(
+                "政治家名", value=extracted.extracted_politician_name or ""
+            )
+            party_name = st.text_input(
+                "政党名", value=extracted.extracted_party_name or ""
+            )
+            parliamentary_group = st.text_input(
+                "議員団名", value=extracted.extracted_parliamentary_group_name or ""
+            )
+            judgment = st.selectbox(
+                "賛否",
+                options=["賛成", "反対", "棄権", "欠席"],
+                index=["賛成", "反対", "棄権", "欠席"].index(
+                    extracted.extracted_judgment
+                )
+                if extracted.extracted_judgment in ["賛成", "反対", "棄権", "欠席"]
+                else 0,
+            )
+
+            col1, col2 = st.columns(2)
+            with col1:
+                if st.form_submit_button("更新"):
+                    extracted.extracted_politician_name = (
+                        politician_name if politician_name else None
+                    )
+                    extracted.extracted_party_name = party_name if party_name else None
+                    extracted.extracted_parliamentary_group_name = (
+                        parliamentary_group if parliamentary_group else None
+                    )
+                    extracted.extracted_judgment = judgment
+
+                    if extracted_repo.update(extracted):
+                        st.success("抽出結果を更新しました")
+                        del st.session_state.edit_extracted_id
+                        st.rerun()
+                    else:
+                        st.error("更新に失敗しました")
+
+            with col2:
+                if st.form_submit_button("キャンセル"):
+                    del st.session_state.edit_extracted_id
+                    st.rerun()
+
+    extracted_repo.close()
+
+
+def manage_proposal_judges_tab():
+    """確定賛否情報管理タブ."""
+    st.subheader("確定賛否情報一覧")
+
+    # リポジトリ初期化
+    judge_repo = RepositoryAdapter(ProposalJudgeRepositoryImpl)
+    proposal_repo = RepositoryAdapter(ProposalRepositoryImpl)
+    politician_repo = RepositoryAdapter(PoliticianRepositoryImpl)
+
+    # 新規賛否情報登録フォーム
+    with st.expander("新規賛否情報登録", expanded=False):
+        with st.form(key="new_judge_form"):
+            col1, col2 = st.columns(2)
+
+            proposals = proposal_repo.get_all()
+            politicians = politician_repo.get_all()
+
+            with col1:
+                proposal_id = st.selectbox(
+                    "議案",
+                    options=[p.id for p in proposals],
+                    format_func=lambda x: next(
+                        (
+                            f"{p.proposal_number or f'ID:{p.id}'}: {p.content[:30]}..."
+                            for p in proposals
+                            if p.id == x
+                        ),
+                        "",
+                    ),
+                    key="new_judge_proposal",
+                )
+
+            with col2:
+                politician_id = st.selectbox(
+                    "政治家",
+                    options=[p.id for p in politicians],
+                    format_func=lambda x: next(
+                        (
+                            f"{p.name} ({p.party or '無所属'})"
+                            for p in politicians
+                            if p.id == x
+                        ),
+                        "",
+                    ),
+                    key="new_judge_politician",
+                )
+
+            judgment = st.selectbox(
+                "賛否",
+                options=["賛成", "反対", "棄権", "欠席"],
+                key="new_judge_judgment",
+            )
+
+            if st.form_submit_button("登録"):
+                if proposal_id and politician_id:
+                    try:
+                        new_judge = ProposalJudge(
+                            proposal_id=proposal_id,
+                            politician_id=politician_id,
+                            approve=judgment,
+                        )
+                        if judge_repo.create(new_judge):
+                            st.success("賛否情報を登録しました")
+                            st.rerun()
+                        else:
+                            st.error("登録に失敗しました")
+                    except Exception as e:
+                        st.error(f"エラー: {str(e)}")
+                else:
+                    st.error("議案と政治家を選択してください")
+
+    # 確定賛否情報一覧取得
+    judges = judge_repo.get_all()
+    proposals = proposal_repo.get_all()
+    politicians = politician_repo.get_all()
+
+    # IDから名前を引けるようにマップ作成
+    proposal_map = {p.id: p for p in proposals}
+    politician_map = {p.id: p for p in politicians}
+
+    if judges:
+        # 各レコードの表示と操作ボタン
+        for judge in judges:
+            col1, col2, col3 = st.columns([5, 1, 1])
+
+            proposal = proposal_map.get(judge.proposal_id)
+            politician = politician_map.get(judge.politician_id)
+
+            with col1:
+                politician_name = (
+                    politician.name if politician else f"ID:{judge.politician_id}"
+                )
+                if proposal:
+                    prop_num = proposal.proposal_number or f"ID:{proposal.id}"
+                    proposal_text = f"{prop_num}: {proposal.content[:30]}..."
+                else:
+                    proposal_text = f"議案ID:{judge.proposal_id}"
+                st.markdown(f"**{politician_name}** - {judge.approve or '不明'}")
+                st.caption(f"議案: {proposal_text}")
+                if politician and politician.party:
+                    st.caption(f"政党: {politician.party}")
+
+            with col2:
+                if st.button("編集", key=f"edit_judge_{judge.id}"):
+                    st.session_state.edit_judge_id = judge.id
+                    st.rerun()
+
+            with col3:
+                if st.button("削除", key=f"delete_judge_{judge.id}"):
+                    if judge_repo.delete(judge.id):
+                        st.success("賛否情報を削除しました")
+                        st.rerun()
+                    else:
+                        st.error("削除に失敗しました")
+
+            st.divider()
+
+        # 編集モード
+        if "edit_judge_id" in st.session_state:
+            edit_proposal_judge(st.session_state.edit_judge_id)
+
+    else:
+        st.info("確定賛否情報がありません")
+
+    judge_repo.close()
+    proposal_repo.close()
+    politician_repo.close()
+
+
+def edit_proposal_judge(judge_id: int):
+    """確定賛否情報編集フォーム."""
+    st.subheader("賛否情報編集")
+
+    judge_repo = RepositoryAdapter(ProposalJudgeRepositoryImpl)
+    judge = judge_repo.get_by_id(judge_id)
+
+    if judge:
+        with st.form(key=f"edit_judge_form_{judge_id}"):
+            judgment = st.selectbox(
+                "賛否",
+                options=["賛成", "反対", "棄権", "欠席"],
+                index=["賛成", "反対", "棄権", "欠席"].index(judge.approve)
+                if judge.approve in ["賛成", "反対", "棄権", "欠席"]
+                else 0,
+            )
+
+            col1, col2 = st.columns(2)
+            with col1:
+                if st.form_submit_button("更新"):
+                    judge.approve = judgment
+
+                    if judge_repo.update(judge):
+                        st.success("賛否情報を更新しました")
+                        del st.session_state.edit_judge_id
+                        st.rerun()
+                    else:
+                        st.error("更新に失敗しました")
+
+            with col2:
+                if st.form_submit_button("キャンセル"):
+                    del st.session_state.edit_judge_id
+                    st.rerun()
+
+    judge_repo.close()


### PR DESCRIPTION
## 概要
Issue #491 に基づき、議案管理のためのStreamlit UIを実装しました。
議案データの3段階の管理フロー（Proposals → ExtractedProposalJudges → ProposalJudges）を可視化し、操作できるインターフェースを提供します。

## 実装内容

### 1. 3つのタブによる議案管理
- **議案管理タブ**: 議案（Proposals）の登録・編集・削除
- **抽出結果タブ**: LLM抽出結果（ExtractedProposalJudges）の確認・マッチング
- **確定結果タブ**: 確定した賛否情報（ProposalJudges）の管理

### 2. 主な機能

#### 議案管理タブ
- **簡素化された議案登録**: 
  - 会議体を選択
  - 詳細URLと状態URLのみ入力（その他の情報は後でLLMが抽出）
  - submission_dateはNULLで登録（LLMが後から設定）
- **会議体との紐付け**: 
  - 会議体選択により関連会議を動的フィルタリング
  - Streamlitのフォーム制限を考慮し、会議体選択をフォーム外に配置
- 議案の編集・削除機能

#### 抽出結果タブ
- ExtractedProposalJudgesの一覧表示
- マッチング状態による色分け表示
- 個別のマッチング処理ボタン

#### 確定結果タブ  
- ProposalJudgesの一覧表示
- 削除機能

### 3. 技術的な修正

#### SQLAlchemy互換性の修正
- `ExtractedProposalJudgeRepositoryImpl`で動的モデル対応のため`get_all()`メソッドをオーバーライド
- text()クエリを使用した実装に変更

#### 日時処理の改善
- Proposalエンティティのsubmission_dateはISO形式文字列として定義
- リポジトリ実装でISO文字列→datetimeオブジェクトの自動変換を実装

#### Streamlit制限への対応
- フォーム内での動的更新制限に対応するため、会議体選択をフォーム外に配置
- これにより会議選択の動的フィルタリングが正常動作

## テスト結果
- ✅ ruff: すべてのチェックをパス
- ✅ pyright: 型チェックをパス  
- ✅ pytest: 関連テストをパス

## スクリーンショット
（必要に応じて追加）

## 今後の改善案
- LLMによる議案情報の自動抽出機能の実装
- バッチ処理機能の追加（将来的に必要な場合）
- より詳細なフィルタリング機能

## レビューポイント
1. Streamlitのフォーム制限への対応方法（会議体選択の配置）
2. SQLAlchemyの動的モデルへの対応アプローチ
3. 3段階データフローのUI表現

Closes #491