### PR TITLE
feat: Streamlit議案画面に賛否抽出ボタンを追加

### DIFF
--- a/database/02_run_migrations.sql
+++ b/database/02_run_migrations.sql
@@ -27,5 +27,6 @@
 \i /docker-entrypoint-initdb.d/02_migrations/022_add_proposal_metadata.sql
 \i /docker-entrypoint-initdb.d/02_migrations/023_create_extracted_proposal_judges.sql
 \i /docker-entrypoint-initdb.d/02_migrations/024_add_status_url_to_proposals.sql
+\i /docker-entrypoint-initdb.d/02_migrations/025_create_proposal_parliamentary_group_judges.sql
 
 \echo 'Migrations completed.'

--- a/database/migrations/025_create_proposal_parliamentary_group_judges.sql
+++ b/database/migrations/025_create_proposal_parliamentary_group_judges.sql
@@ -1,0 +1,31 @@
+-- 議案への会派単位の賛否情報テーブル
+-- 会派（議員団）が議案に対してどのような判断をしたかを記録
+CREATE TABLE IF NOT EXISTS proposal_parliamentary_group_judges (
+    id SERIAL PRIMARY KEY,
+    proposal_id INTEGER NOT NULL REFERENCES proposals(id),
+    parliamentary_group_id INTEGER NOT NULL REFERENCES parliamentary_groups(id),
+    judgment VARCHAR(50) NOT NULL, -- 賛成/反対/棄権/欠席
+    member_count INTEGER, -- この判断をした会派メンバーの人数
+    note TEXT, -- 備考（例：「自由投票」「一部反対」など）
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    -- 同一議案・会派の重複を防ぐ
+    UNIQUE(proposal_id, parliamentary_group_id)
+);
+
+-- インデックスの作成
+CREATE INDEX idx_proposal_parliamentary_group_judges_proposal
+    ON proposal_parliamentary_group_judges(proposal_id);
+CREATE INDEX idx_proposal_parliamentary_group_judges_group
+    ON proposal_parliamentary_group_judges(parliamentary_group_id);
+CREATE INDEX idx_proposal_parliamentary_group_judges_judgment
+    ON proposal_parliamentary_group_judges(judgment);
+
+-- コメント追加
+COMMENT ON TABLE proposal_parliamentary_group_judges IS '議案への会派単位の賛否情報';
+COMMENT ON COLUMN proposal_parliamentary_group_judges.proposal_id IS '議案ID';
+COMMENT ON COLUMN proposal_parliamentary_group_judges.parliamentary_group_id IS '会派ID';
+COMMENT ON COLUMN proposal_parliamentary_group_judges.judgment IS '賛否判断（賛成/反対/棄権/欠席）';
+COMMENT ON COLUMN proposal_parliamentary_group_judges.member_count IS 'この判断をした会派メンバーの人数';
+COMMENT ON COLUMN proposal_parliamentary_group_judges.note IS '備考（自由投票など特記事項）';

--- a/src/domain/entities/extracted_proposal_judge.py
+++ b/src/domain/entities/extracted_proposal_judge.py
@@ -65,6 +65,24 @@ class ExtractedProposalJudge(BaseEntity):
             "approve": self.extracted_judgment,
         }
 
+    def convert_to_parliamentary_group_judge_params(self) -> dict[str, Any]:
+        """Convert to ProposalParliamentaryGroupJudge creation parameters."""
+        if not self.is_matched():
+            raise ValueError(
+                f"Cannot convert unmatched extracted judge "
+                f"(status: {self.matching_status})"
+            )
+        if not self.matched_parliamentary_group_id:
+            raise ValueError(
+                "Matched parliamentary group ID is required for conversion"
+            )
+
+        return {
+            "proposal_id": self.proposal_id,
+            "parliamentary_group_id": self.matched_parliamentary_group_id,
+            "judgment": self.extracted_judgment,
+        }
+
     def __str__(self) -> str:
         identifier = (
             self.extracted_politician_name

--- a/src/domain/entities/proposal_parliamentary_group_judge.py
+++ b/src/domain/entities/proposal_parliamentary_group_judge.py
@@ -1,0 +1,56 @@
+"""ProposalParliamentaryGroupJudge entity module."""
+
+from src.domain.entities.base import BaseEntity
+
+
+class ProposalParliamentaryGroupJudge(BaseEntity):
+    """議案への会派単位の賛否情報を表すエンティティ."""
+
+    def __init__(
+        self,
+        proposal_id: int,
+        parliamentary_group_id: int,
+        judgment: str,
+        member_count: int | None = None,
+        note: str | None = None,
+        id: int | None = None,
+    ) -> None:
+        """Initialize ProposalParliamentaryGroupJudge entity.
+
+        Args:
+            proposal_id: 議案ID
+            parliamentary_group_id: 会派ID
+            judgment: 賛否判断（賛成/反対/棄権/欠席）
+            member_count: この判断をした会派メンバーの人数
+            note: 備考（自由投票など特記事項）
+            id: エンティティID
+        """
+        super().__init__(id)
+        self.proposal_id = proposal_id
+        self.parliamentary_group_id = parliamentary_group_id
+        self.judgment = judgment
+        self.member_count = member_count
+        self.note = note
+
+    def is_approve(self) -> bool:
+        """賛成かどうかを判定."""
+        return self.judgment == "賛成"
+
+    def is_oppose(self) -> bool:
+        """反対かどうかを判定."""
+        return self.judgment == "反対"
+
+    def is_abstain(self) -> bool:
+        """棄権かどうかを判定."""
+        return self.judgment == "棄権"
+
+    def is_absent(self) -> bool:
+        """欠席かどうかを判定."""
+        return self.judgment == "欠席"
+
+    def __str__(self) -> str:
+        return (
+            f"ProposalParliamentaryGroupJudge: "
+            f"Group {self.parliamentary_group_id} - {self.judgment}"
+            f"{f' ({self.member_count}人)' if self.member_count else ''}"
+        )

--- a/src/domain/repositories/proposal_parliamentary_group_judge_repository.py
+++ b/src/domain/repositories/proposal_parliamentary_group_judge_repository.py
@@ -1,0 +1,71 @@
+"""ProposalParliamentaryGroupJudge repository interface."""
+
+from abc import abstractmethod
+
+from src.domain.entities.proposal_parliamentary_group_judge import (
+    ProposalParliamentaryGroupJudge,
+)
+from src.domain.repositories.base import BaseRepository
+
+
+class ProposalParliamentaryGroupJudgeRepository(
+    BaseRepository[ProposalParliamentaryGroupJudge]
+):
+    """Repository interface for ProposalParliamentaryGroupJudge entities."""
+
+    @abstractmethod
+    async def get_by_proposal(
+        self, proposal_id: int
+    ) -> list[ProposalParliamentaryGroupJudge]:
+        """Get all parliamentary group judges for a specific proposal.
+
+        Args:
+            proposal_id: ID of the proposal
+
+        Returns:
+            List of ProposalParliamentaryGroupJudge entities
+        """
+        pass
+
+    @abstractmethod
+    async def get_by_parliamentary_group(
+        self, parliamentary_group_id: int
+    ) -> list[ProposalParliamentaryGroupJudge]:
+        """Get all proposal judges for a specific parliamentary group.
+
+        Args:
+            parliamentary_group_id: ID of the parliamentary group
+
+        Returns:
+            List of ProposalParliamentaryGroupJudge entities
+        """
+        pass
+
+    @abstractmethod
+    async def get_by_proposal_and_group(
+        self, proposal_id: int, parliamentary_group_id: int
+    ) -> ProposalParliamentaryGroupJudge | None:
+        """Get judge for a specific proposal and parliamentary group.
+
+        Args:
+            proposal_id: ID of the proposal
+            parliamentary_group_id: ID of the parliamentary group
+
+        Returns:
+            ProposalParliamentaryGroupJudge entity or None if not found
+        """
+        pass
+
+    @abstractmethod
+    async def bulk_create(
+        self, judges: list[ProposalParliamentaryGroupJudge]
+    ) -> list[ProposalParliamentaryGroupJudge]:
+        """Create multiple parliamentary group judges at once.
+
+        Args:
+            judges: List of ProposalParliamentaryGroupJudge entities to create
+
+        Returns:
+            List of created ProposalParliamentaryGroupJudge entities with IDs
+        """
+        pass

--- a/src/domain/services/proposal_judge_extraction_service.py
+++ b/src/domain/services/proposal_judge_extraction_service.py
@@ -25,16 +25,12 @@ class ProposalJudgeExtractionService:
 
         # Map Japanese and English variations to standard types
         if text in ["賛成", "APPROVE", "YES", "FOR", "賛", "○"]:
-            return ("APPROVE", True)
+            return ("賛成", True)
         elif text in ["反対", "OPPOSE", "NO", "AGAINST", "反", "×", "✕"]:
-            return ("OPPOSE", True)
-        elif text in ["棄権", "ABSTAIN", "ABSTENTION", "棄"]:
-            return ("ABSTAIN", True)
-        elif text in ["欠席", "ABSENT", "ABSENCE", "欠", "－"]:
-            return ("ABSENT", True)
+            return ("反対", True)
         else:
-            # Return APPROVE as default but indicate it was unknown
-            return ("APPROVE", False)
+            # Return 賛成 as default but indicate it was unknown
+            return ("賛成", False)
 
     @staticmethod
     def normalize_politician_name(name: str) -> str:
@@ -120,12 +116,10 @@ class ProposalJudgeExtractionService:
         """
         results = []
 
-        # Split text into sections (approve, oppose, abstain, absent)
+        # Split text into sections (approve, oppose)
         sections = {
-            "APPROVE": ["賛成", "賛成者", "賛成議員", "可決", "承認"],
-            "OPPOSE": ["反対", "反対者", "反対議員", "否決", "不承認"],
-            "ABSTAIN": ["棄権", "棄権者", "棄権議員"],
-            "ABSENT": ["欠席", "欠席者", "欠席議員", "不在"],
+            "賛成": ["賛成", "賛成者", "賛成議員", "可決", "承認"],
+            "反対": ["反対", "反対者", "反対議員", "否決", "不承認"],
         }
 
         current_judgment = None
@@ -141,6 +135,14 @@ class ProposalJudgeExtractionService:
                 if any(keyword in line for keyword in keywords):
                     current_judgment = judgment
                     break
+
+            # 棄権や欠席のセクションは無視（賛成・反対のみ処理）
+            if any(
+                keyword in line
+                for keyword in ["棄権", "欠席", "退席", "ABSTAIN", "ABSENT"]
+            ):
+                current_judgment = None
+                continue
 
             # If we have a current judgment and the line contains names
             if current_judgment and not any(

--- a/src/infrastructure/external/web_scraper_service.py
+++ b/src/infrastructure/external/web_scraper_service.py
@@ -360,6 +360,10 @@ class PlaywrightScraperService(IWebScraperService):
                     else:
                         response_text = str(response)
 
+                    # Ensure response_text is a string
+                    if not isinstance(response_text, str):
+                        response_text = str(response_text)
+
                     # Try to extract JSON from the response
                     # Remove markdown code blocks if present
                     response_text = response_text.strip()

--- a/src/infrastructure/persistence/extracted_proposal_judge_repository_impl.py
+++ b/src/infrastructure/persistence/extracted_proposal_judge_repository_impl.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from typing import Any
 
+from pydantic import BaseModel as PydanticBaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,27 +15,26 @@ from src.domain.repositories.extracted_proposal_judge_repository import (
 from src.infrastructure.persistence.base_repository_impl import BaseRepositoryImpl
 
 
-class ExtractedProposalJudgeModel:
-    """Extracted proposal judge database model (dynamic)."""
+class ExtractedProposalJudgeModel(PydanticBaseModel):
+    """Extracted proposal judge database model."""
 
-    id: int | None
+    id: int | None = None
     proposal_id: int
-    extracted_politician_name: str | None
-    extracted_party_name: str | None
-    extracted_parliamentary_group_name: str | None
-    extracted_judgment: str | None
-    source_url: str | None
+    extracted_politician_name: str | None = None
+    extracted_party_name: str | None = None
+    extracted_parliamentary_group_name: str | None = None
+    extracted_judgment: str | None = None
+    source_url: str | None = None
     extracted_at: datetime
-    matched_politician_id: int | None
-    matched_parliamentary_group_id: int | None
-    matching_confidence: float | None
-    matching_status: str
-    matched_at: datetime | None
-    additional_data: str | None
+    matched_politician_id: int | None = None
+    matched_parliamentary_group_id: int | None = None
+    matching_confidence: float | None = None
+    matching_status: str = "pending"
+    matched_at: datetime | None = None
+    additional_data: str | None = None
 
-    def __init__(self, **kwargs: Any):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class ExtractedProposalJudgeRepositoryImpl(

--- a/src/infrastructure/persistence/proposal_parliamentary_group_judge_repository_impl.py
+++ b/src/infrastructure/persistence/proposal_parliamentary_group_judge_repository_impl.py
@@ -1,0 +1,255 @@
+"""ProposalParliamentaryGroupJudge repository implementation."""
+
+from typing import Any
+
+from pydantic import BaseModel as PydanticBaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.entities.proposal_parliamentary_group_judge import (
+    ProposalParliamentaryGroupJudge,
+)
+from src.domain.repositories.proposal_parliamentary_group_judge_repository import (
+    ProposalParliamentaryGroupJudgeRepository,
+)
+from src.infrastructure.persistence.base_repository_impl import BaseRepositoryImpl
+
+
+class ProposalParliamentaryGroupJudgeModel(PydanticBaseModel):
+    """Proposal parliamentary group judge database model."""
+
+    id: int | None = None
+    proposal_id: int
+    parliamentary_group_id: int
+    judgment: str
+    member_count: int | None = None
+    note: str | None = None
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class ProposalParliamentaryGroupJudgeRepositoryImpl(
+    BaseRepositoryImpl[ProposalParliamentaryGroupJudge],
+    ProposalParliamentaryGroupJudgeRepository,
+):
+    """Implementation of ProposalParliamentaryGroupJudgeRepository."""
+
+    def __init__(self, session: AsyncSession):
+        super().__init__(
+            session,
+            ProposalParliamentaryGroupJudge,
+            ProposalParliamentaryGroupJudgeModel,
+        )
+
+    async def get_by_id(self, entity_id: int) -> ProposalParliamentaryGroupJudge | None:
+        """Get entity by ID."""
+        query = text("""
+            SELECT * FROM proposal_parliamentary_group_judges WHERE id = :id
+        """)
+        result = await self.session.execute(query, {"id": entity_id})
+        row = result.fetchone()
+        if row:
+            return self._row_to_entity(row)
+        return None
+
+    async def create(
+        self, entity: ProposalParliamentaryGroupJudge
+    ) -> ProposalParliamentaryGroupJudge:
+        """Create a new entity."""
+        query = text("""
+            INSERT INTO proposal_parliamentary_group_judges (
+                proposal_id, parliamentary_group_id, judgment,
+                member_count, note
+            )
+            VALUES (
+                :proposal_id, :parliamentary_group_id, :judgment,
+                :member_count, :note
+            )
+            RETURNING id, proposal_id, parliamentary_group_id, judgment,
+                      member_count, note, created_at, updated_at
+        """)
+
+        params = {
+            "proposal_id": entity.proposal_id,
+            "parliamentary_group_id": entity.parliamentary_group_id,
+            "judgment": entity.judgment,
+            "member_count": entity.member_count,
+            "note": entity.note,
+        }
+
+        result = await self.session.execute(query, params)
+        row = result.fetchone()
+        await self.session.commit()
+
+        if row:
+            return self._row_to_entity(row)
+        raise RuntimeError("Failed to create proposal parliamentary group judge")
+
+    async def get_all(
+        self, limit: int | None = None, offset: int | None = None
+    ) -> list[ProposalParliamentaryGroupJudge]:
+        """Get all entities with optional pagination."""
+        query_str = "SELECT * FROM proposal_parliamentary_group_judges ORDER BY id"
+        params: dict[str, Any] = {}
+
+        if limit:
+            query_str += " LIMIT :limit"
+            params["limit"] = limit
+        if offset:
+            query_str += " OFFSET :offset"
+            params["offset"] = offset
+
+        query = text(query_str)
+        result = await self.session.execute(query, params)
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
+    async def get_by_proposal(
+        self, proposal_id: int
+    ) -> list[ProposalParliamentaryGroupJudge]:
+        """Get all parliamentary group judges for a specific proposal."""
+        query = text("""
+            SELECT * FROM proposal_parliamentary_group_judges
+            WHERE proposal_id = :proposal_id
+            ORDER BY parliamentary_group_id
+        """)
+
+        result = await self.session.execute(query, {"proposal_id": proposal_id})
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
+    async def get_by_parliamentary_group(
+        self, parliamentary_group_id: int
+    ) -> list[ProposalParliamentaryGroupJudge]:
+        """Get all proposal judges for a specific parliamentary group."""
+        query = text("""
+            SELECT * FROM proposal_parliamentary_group_judges
+            WHERE parliamentary_group_id = :parliamentary_group_id
+            ORDER BY proposal_id
+        """)
+
+        result = await self.session.execute(
+            query, {"parliamentary_group_id": parliamentary_group_id}
+        )
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
+    async def get_by_proposal_and_group(
+        self, proposal_id: int, parliamentary_group_id: int
+    ) -> ProposalParliamentaryGroupJudge | None:
+        """Get judge for a specific proposal and parliamentary group."""
+        query = text("""
+            SELECT * FROM proposal_parliamentary_group_judges
+            WHERE proposal_id = :proposal_id
+              AND parliamentary_group_id = :parliamentary_group_id
+        """)
+
+        result = await self.session.execute(
+            query,
+            {
+                "proposal_id": proposal_id,
+                "parliamentary_group_id": parliamentary_group_id,
+            },
+        )
+        row = result.fetchone()
+
+        if row:
+            return self._row_to_entity(row)
+        return None
+
+    async def bulk_create(
+        self, judges: list[ProposalParliamentaryGroupJudge]
+    ) -> list[ProposalParliamentaryGroupJudge]:
+        """Create multiple parliamentary group judges at once."""
+        if not judges:
+            return []
+
+        # Build values for bulk insert
+        values = []
+        for judge in judges:
+            values.append(
+                {
+                    "proposal_id": judge.proposal_id,
+                    "parliamentary_group_id": judge.parliamentary_group_id,
+                    "judgment": judge.judgment,
+                    "member_count": judge.member_count,
+                    "note": judge.note,
+                }
+            )
+
+        # Create bulk insert query
+        query = text("""
+            INSERT INTO proposal_parliamentary_group_judges (
+                proposal_id, parliamentary_group_id, judgment,
+                member_count, note
+            )
+            VALUES (
+                :proposal_id, :parliamentary_group_id, :judgment,
+                :member_count, :note
+            )
+            RETURNING id, proposal_id, parliamentary_group_id, judgment,
+                      member_count, note, created_at, updated_at
+        """)
+
+        created_judges = []
+        for value in values:
+            result = await self.session.execute(query, value)
+            row = result.fetchone()
+            if row:
+                created_judges.append(self._row_to_entity(row))
+
+        await self.session.commit()
+        return created_judges
+
+    def _row_to_entity(self, row: Any) -> ProposalParliamentaryGroupJudge:
+        """Convert database row to domain entity."""
+        return ProposalParliamentaryGroupJudge(
+            id=row.id,
+            proposal_id=row.proposal_id,
+            parliamentary_group_id=row.parliamentary_group_id,
+            judgment=row.judgment,
+            member_count=getattr(row, "member_count", None),
+            note=getattr(row, "note", None),
+        )
+
+    def _to_entity(
+        self, model: ProposalParliamentaryGroupJudgeModel
+    ) -> ProposalParliamentaryGroupJudge:
+        """Convert database model to domain entity."""
+        return ProposalParliamentaryGroupJudge(
+            id=model.id,
+            proposal_id=model.proposal_id,
+            parliamentary_group_id=model.parliamentary_group_id,
+            judgment=model.judgment,
+            member_count=model.member_count,
+            note=model.note,
+        )
+
+    def _to_model(
+        self, entity: ProposalParliamentaryGroupJudge
+    ) -> ProposalParliamentaryGroupJudgeModel:
+        """Convert domain entity to database model."""
+        return ProposalParliamentaryGroupJudgeModel(
+            id=entity.id,
+            proposal_id=entity.proposal_id,
+            parliamentary_group_id=entity.parliamentary_group_id,
+            judgment=entity.judgment,
+            member_count=entity.member_count,
+            note=entity.note,
+        )
+
+    def _update_model(
+        self,
+        model: ProposalParliamentaryGroupJudgeModel,
+        entity: ProposalParliamentaryGroupJudge,
+    ) -> None:
+        """Update model fields from entity."""
+        model.proposal_id = entity.proposal_id
+        model.parliamentary_group_id = entity.parliamentary_group_id
+        model.judgment = entity.judgment
+        model.member_count = entity.member_count
+        model.note = entity.note

--- a/src/streamlit/pages/proposals.py
+++ b/src/streamlit/pages/proposals.py
@@ -738,15 +738,15 @@ def manage_extracted_judges_tab():
                             else:
                                 st.error("削除に失敗しました")
 
-                # 編集モードの場合、このレコードの直下に編集フォームを表示
-                if (
-                    "edit_extracted_id" in st.session_state
-                    and st.session_state.edit_extracted_id == judge.id
-                ):
-                    with st.container():
-                        st.divider()
-                        edit_extracted_judge(judge.id)
-                        st.divider()
+                    # 編集モードの場合、このレコードの直下に編集フォームを表示
+                    if (
+                        "edit_extracted_id" in st.session_state
+                        and st.session_state.edit_extracted_id == judge.id
+                    ):
+                        with st.container():
+                            st.divider()
+                            edit_extracted_judge(judge.id)
+                            st.divider()
 
                     st.divider()
 

--- a/src/streamlit/pages/proposals.py
+++ b/src/streamlit/pages/proposals.py
@@ -211,6 +211,8 @@ def manage_proposals_tab():
                 st.caption(f"提出者: {row['submitter']} | 状態: {row['status']}")
                 if row["detail_url"]:
                     st.caption(f"詳細URL: {row['detail_url']}")
+                if row["status_url"]:
+                    st.caption(f"状態URL: {row['status_url']}")
 
             with col2:
                 if st.button("編集", key=f"edit_proposal_{row['id']}"):

--- a/src/streamlit/pages/proposals.py
+++ b/src/streamlit/pages/proposals.py
@@ -279,6 +279,7 @@ def manage_proposals_tab():
                 if status_url:
                     if st.button("賛否抽出", key=f"extract_judges_{row['id']}"):
                         with st.spinner("賛否情報を抽出中..."):
+                            sync_session = None
                             try:
                                 # ExtractProposalJudgesUseCaseの初期化
                                 from src.config.database import get_db_session
@@ -341,11 +342,8 @@ def manage_proposals_tab():
                                 )
 
                                 # 非同期処理を同期的に実行
-                                loop = asyncio.new_event_loop()
-                                asyncio.set_event_loop(loop)
-                                result = loop.run_until_complete(
-                                    use_case.extract_judges(input_dto)
-                                )
+                                # Streamlitでは asyncio.run() を使用する
+                                result = asyncio.run(use_case.extract_judges(input_dto))
 
                                 if result and result.extracted_count > 0:
                                     st.success(
@@ -372,6 +370,10 @@ def manage_proposals_tab():
                                     )
                                 else:
                                     st.error(f"エラーが発生しました: {error_msg}")
+                            finally:
+                                # セッションを確実にクローズ
+                                if sync_session:
+                                    sync_session.close()
                 else:
                     st.button(
                         "賛否抽出",


### PR DESCRIPTION
## 概要
ExtractedProposalJudges（LLM抽出結果）の手動紐付け機能を実装し、議員・議員団への紐付けから最終的な確定までのワークフローを完成させました。

## 変更内容

### 🎯 機能追加
- **手動紐付け機能**
  - ExtractedProposalJudgesタブで議員・議員団への手動紐付けが可能に
  - 編集フォームを対象レコードの直下に展開（どのレコードを編集中か明確に）
  - 議案の開催主体（Conference）に紐づく候補のみ表示するフィルタリング機能

### 🎨 UI/UX改善
- **操作性向上**
  - 編集中のレコードのボタンが「キャンセル」に変更
  - 人手による紐付けは信頼度100%固定（スライダーを削除してシンプルに）
  
- **判定値の統一**
  - 賛否判定を日本語（賛成/反対）に統一
  - 棄権・欠席ステータスを削除（賛成/反対のみにフォーカス）

### 🐛 バグ修正
- `proposal_parliamentary_group_judges`テーブルが存在しない問題を修正
  - マイグレーション025を手動実行
- 確定賛否情報タブに議員団の賛否も表示されるよう修正
  - ProposalJudgeとProposalParliamentaryGroupJudgeの両方を表示

### 🔧 技術的変更
- `ProposalJudgeExtractionService`の判定値を日本語に統一
  - "APPROVE" → "賛成"、"OPPOSE" → "反対"
- `ExtractedProposalJudgeRepository`のdelete操作を修正
  - AsyncSessionでrowcountが使えない問題に対応
- テストケースを新仕様に合わせて更新

## 動作確認
- [x] ruffでコードフォーマットとリントを実行
- [x] pytestでテストがパス（24 passed）
- [x] 手動紐付け機能が正常に動作
- [x] Conference-basedフィルタリングが機能
- [x] 確定処理が正常に完了

## スクリーンショット/動作例

### 手動紐付けワークフロー
1. ExtractedProposalJudgesタブで「編集・紐付け」ボタンをクリック
2. 対象レコードの直下に編集フォームが展開
3. 議員または議員団を選択（開催主体に所属する候補のみ表示）
4. 「保存して確定」で最終データに変換

### テスト結果
```
============================= 24 passed in 0.05s =============================
```

## 関連Issue
- #490 議案賛否抽出機能の実装

## 注意事項
- pyrightで一部の型チェック警告が残っていますが、動作には影響ありません
- `proposal_parliamentary_group_judges`テーブルは新規デプロイ時に自動作成されます

🤖 Generated with Claude Code