### PR TITLE
[PBI-001] ExtractedPoliticianエンティティとリポジトリの実装

### DIFF
--- a/src/domain/entities/extracted_politician.py
+++ b/src/domain/entities/extracted_politician.py
@@ -1,0 +1,72 @@
+"""ExtractedPolitician entity module."""
+
+from datetime import datetime
+
+from src.domain.entities.base import BaseEntity
+
+
+class ExtractedPolitician(BaseEntity):
+    """LLMが抽出した政治家データの中間オブジェクトを表すエンティティ."""
+
+    def __init__(
+        self,
+        name: str,
+        party_id: int | None = None,
+        district: str | None = None,
+        position: str | None = None,
+        profile_url: str | None = None,
+        image_url: str | None = None,
+        status: str = "pending",
+        extracted_at: datetime | None = None,
+        reviewed_at: datetime | None = None,
+        reviewer_id: int | None = None,
+        id: int | None = None,
+    ) -> None:
+        super().__init__(id)
+        self.name = name
+        self.party_id = party_id
+        self.district = district
+        self.position = position
+        self.profile_url = profile_url
+        self.image_url = image_url
+        self.status = status
+        self.extracted_at = extracted_at or datetime.now()
+        self.reviewed_at = reviewed_at
+        self.reviewer_id = reviewer_id
+
+    def is_pending(self) -> bool:
+        """Check if the politician data is pending review."""
+        return self.status == "pending"
+
+    def is_reviewed(self) -> bool:
+        """Check if the politician data has been reviewed."""
+        return self.status == "reviewed"
+
+    def is_approved(self) -> bool:
+        """Check if the politician data has been approved."""
+        return self.status == "approved"
+
+    def is_rejected(self) -> bool:
+        """Check if the politician data has been rejected."""
+        return self.status == "rejected"
+
+    def mark_as_reviewed(self, reviewer_id: int) -> None:
+        """Mark the politician data as reviewed."""
+        self.status = "reviewed"
+        self.reviewed_at = datetime.now()
+        self.reviewer_id = reviewer_id
+
+    def approve(self, reviewer_id: int) -> None:
+        """Approve the politician data."""
+        self.status = "approved"
+        self.reviewed_at = datetime.now()
+        self.reviewer_id = reviewer_id
+
+    def reject(self, reviewer_id: int) -> None:
+        """Reject the politician data."""
+        self.status = "rejected"
+        self.reviewed_at = datetime.now()
+        self.reviewer_id = reviewer_id
+
+    def __str__(self) -> str:
+        return f"ExtractedPolitician(name={self.name}, status={self.status})"

--- a/src/domain/repositories/extracted_politician_repository.py
+++ b/src/domain/repositories/extracted_politician_repository.py
@@ -1,0 +1,56 @@
+"""ExtractedPolitician repository interface."""
+
+from abc import abstractmethod
+
+from src.domain.entities.extracted_politician import ExtractedPolitician
+from src.domain.repositories.base import BaseRepository
+
+
+class ExtractedPoliticianRepository(BaseRepository[ExtractedPolitician]):
+    """Repository interface for extracted politicians."""
+
+    @abstractmethod
+    async def get_pending(
+        self, party_id: int | None = None
+    ) -> list[ExtractedPolitician]:
+        """Get all pending politicians for review."""
+        pass
+
+    @abstractmethod
+    async def get_by_status(self, status: str) -> list[ExtractedPolitician]:
+        """Get all politicians by status."""
+        pass
+
+    @abstractmethod
+    async def get_by_party(self, party_id: int) -> list[ExtractedPolitician]:
+        """Get all extracted politicians for a party."""
+        pass
+
+    @abstractmethod
+    async def update_status(
+        self,
+        politician_id: int,
+        status: str,
+        reviewer_id: int | None = None,
+    ) -> ExtractedPolitician | None:
+        """Update the status for a politician."""
+        pass
+
+    @abstractmethod
+    async def get_summary_by_status(self) -> dict[str, int]:
+        """Get summary statistics grouped by status."""
+        pass
+
+    @abstractmethod
+    async def bulk_create(
+        self, politicians: list[ExtractedPolitician]
+    ) -> list[ExtractedPolitician]:
+        """Create multiple extracted politicians at once."""
+        pass
+
+    @abstractmethod
+    async def get_duplicates(
+        self, name: str, party_id: int | None = None
+    ) -> list[ExtractedPolitician]:
+        """Find potential duplicate extracted politicians by name and party."""
+        pass

--- a/src/infrastructure/persistence/extracted_politician_repository_impl.py
+++ b/src/infrastructure/persistence/extracted_politician_repository_impl.py
@@ -1,0 +1,241 @@
+"""ExtractedPolitician repository implementation using SQLAlchemy."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.entities.extracted_politician import ExtractedPolitician
+from src.domain.repositories.extracted_politician_repository import (
+    ExtractedPoliticianRepository as IExtractedPoliticianRepository,
+)
+from src.infrastructure.persistence.base_repository_impl import BaseRepositoryImpl
+
+
+class ExtractedPoliticianModel:
+    """Extracted politician database model (dynamic)."""
+
+    id: int | None
+    name: str
+    party_id: int | None
+    district: str | None
+    position: str | None
+    profile_url: str | None
+    image_url: str | None
+    status: str
+    extracted_at: datetime
+    reviewed_at: datetime | None
+    reviewer_id: int | None
+    created_at: datetime | None
+    updated_at: datetime | None
+
+    def __init__(self, **kwargs: Any):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class ExtractedPoliticianRepositoryImpl(
+    BaseRepositoryImpl[ExtractedPolitician], IExtractedPoliticianRepository
+):
+    """Implementation of ExtractedPoliticianRepository using SQLAlchemy."""
+
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, ExtractedPolitician, ExtractedPoliticianModel)
+
+    async def get_pending(
+        self, party_id: int | None = None
+    ) -> list[ExtractedPolitician]:
+        """Get all pending politicians for review."""
+        conditions = ["status = 'pending'"]
+        params: dict[str, Any] = {}
+
+        if party_id is not None:
+            conditions.append("party_id = :party_id")
+            params["party_id"] = party_id
+
+        query = text(f"""
+            SELECT * FROM extracted_politicians
+            WHERE {" AND ".join(conditions)}
+            ORDER BY extracted_at DESC
+        """)
+
+        result = await self.session.execute(query, params)
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
+    async def get_by_status(self, status: str) -> list[ExtractedPolitician]:
+        """Get all politicians by status."""
+        query = text("""
+            SELECT * FROM extracted_politicians
+            WHERE status = :status
+            ORDER BY extracted_at DESC
+        """)
+
+        result = await self.session.execute(query, {"status": status})
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
+    async def get_by_party(self, party_id: int) -> list[ExtractedPolitician]:
+        """Get all extracted politicians for a party."""
+        query = text("""
+            SELECT * FROM extracted_politicians
+            WHERE party_id = :party_id
+            ORDER BY name
+        """)
+
+        result = await self.session.execute(query, {"party_id": party_id})
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
+    async def update_status(
+        self,
+        politician_id: int,
+        status: str,
+        reviewer_id: int | None = None,
+    ) -> ExtractedPolitician | None:
+        """Update the status for a politician."""
+        params: dict[str, Any] = {
+            "politician_id": politician_id,
+            "status": status,
+            "updated_at": datetime.now(),
+        }
+
+        if status in ["reviewed", "approved", "rejected"]:
+            params["reviewed_at"] = datetime.now()
+            params["reviewer_id"] = reviewer_id
+        else:
+            params["reviewed_at"] = None
+            params["reviewer_id"] = None
+
+        query = text("""
+            UPDATE extracted_politicians
+            SET status = :status,
+                reviewed_at = :reviewed_at,
+                reviewer_id = :reviewer_id,
+                updated_at = :updated_at
+            WHERE id = :politician_id
+        """)
+
+        await self.session.execute(query, params)
+        await self.session.commit()
+
+        # Return updated entity
+        return await self.get_by_id(politician_id)
+
+    async def get_summary_by_status(self) -> dict[str, int]:
+        """Get summary statistics grouped by status."""
+        query = text("""
+            SELECT status, COUNT(*) as count
+            FROM extracted_politicians
+            GROUP BY status
+        """)
+
+        result = await self.session.execute(query)
+        rows = result.fetchall()
+
+        summary = {
+            "total": 0,
+            "pending": 0,
+            "reviewed": 0,
+            "approved": 0,
+            "rejected": 0,
+        }
+
+        for row in rows:
+            status = row.status
+            count = getattr(row, "count", 0)  # Use getattr to access the count
+            if status in summary:
+                summary[status] = count
+            summary["total"] += count
+
+        return summary
+
+    async def bulk_create(
+        self, politicians: list[ExtractedPolitician]
+    ) -> list[ExtractedPolitician]:
+        """Create multiple extracted politicians at once."""
+        models = [self._to_model(politician) for politician in politicians]
+        self.session.add_all(models)
+        await self.session.commit()
+
+        # Refresh all models to get IDs
+        for model in models:
+            await self.session.refresh(model)
+
+        return [self._to_entity(model) for model in models]
+
+    async def get_duplicates(
+        self, name: str, party_id: int | None = None
+    ) -> list[ExtractedPolitician]:
+        """Find potential duplicate extracted politicians by name and party."""
+        conditions = ["LOWER(name) = LOWER(:name)"]
+        params: dict[str, Any] = {"name": name}
+
+        if party_id is not None:
+            conditions.append("party_id = :party_id")
+            params["party_id"] = party_id
+
+        query = text(f"""
+            SELECT * FROM extracted_politicians
+            WHERE {" AND ".join(conditions)}
+            ORDER BY extracted_at DESC
+        """)
+
+        result = await self.session.execute(query, params)
+        rows = result.fetchall()
+
+        return [self._row_to_entity(row) for row in rows]
+
+    def _row_to_entity(self, row: Any) -> ExtractedPolitician:
+        """Convert database row to domain entity."""
+        return ExtractedPolitician(
+            id=row.id,
+            name=row.name,
+            party_id=row.party_id,
+            district=row.district,
+            position=row.position,
+            profile_url=row.profile_url,
+            image_url=row.image_url,
+            status=row.status,
+            extracted_at=row.extracted_at,
+            reviewed_at=row.reviewed_at,
+            reviewer_id=row.reviewer_id,
+        )
+
+    def _to_entity(self, model: ExtractedPoliticianModel) -> ExtractedPolitician:
+        """Convert model to domain entity."""
+        return ExtractedPolitician(
+            id=model.id,
+            name=model.name,
+            party_id=model.party_id,
+            district=model.district,
+            position=model.position,
+            profile_url=model.profile_url,
+            image_url=model.image_url,
+            status=model.status,
+            extracted_at=model.extracted_at,
+            reviewed_at=model.reviewed_at,
+            reviewer_id=model.reviewer_id,
+        )
+
+    def _to_model(self, entity: ExtractedPolitician) -> ExtractedPoliticianModel:
+        """Convert domain entity to model."""
+        model = ExtractedPoliticianModel()
+        model.id = entity.id
+        model.name = entity.name
+        model.party_id = entity.party_id
+        model.district = entity.district
+        model.position = entity.position
+        model.profile_url = entity.profile_url
+        model.image_url = entity.image_url
+        model.status = entity.status
+        model.extracted_at = entity.extracted_at
+        model.reviewed_at = entity.reviewed_at
+        model.reviewer_id = entity.reviewer_id
+        model.created_at = entity.created_at
+        model.updated_at = entity.updated_at
+        return model

--- a/tests/domain/entities/test_extracted_politician.py
+++ b/tests/domain/entities/test_extracted_politician.py
@@ -1,0 +1,283 @@
+"""Tests for ExtractedPolitician entity."""
+
+from datetime import datetime
+
+from src.domain.entities.extracted_politician import ExtractedPolitician
+from tests.fixtures.entity_factories import create_extracted_politician
+
+
+class TestExtractedPolitician:
+    """Test cases for ExtractedPolitician entity."""
+
+    def test_initialization_with_required_fields(self) -> None:
+        """Test entity initialization with required fields only."""
+        politician = ExtractedPolitician(
+            name="山田太郎",
+        )
+
+        assert politician.name == "山田太郎"
+        assert politician.party_id is None
+        assert politician.district is None
+        assert politician.position is None
+        assert politician.profile_url is None
+        assert politician.image_url is None
+        assert politician.status == "pending"
+        assert isinstance(politician.extracted_at, datetime)
+        assert politician.reviewed_at is None
+        assert politician.reviewer_id is None
+
+    def test_initialization_with_all_fields(self) -> None:
+        """Test entity initialization with all fields."""
+        extracted_at = datetime(2023, 1, 1, 12, 0, 0)
+        reviewed_at = datetime(2023, 1, 2, 12, 0, 0)
+
+        politician = ExtractedPolitician(
+            id=1,
+            name="山田太郎",
+            party_id=1,
+            district="東京1区",
+            position="衆議院議員",
+            profile_url="https://example.com/profile",
+            image_url="https://example.com/image.jpg",
+            status="approved",
+            extracted_at=extracted_at,
+            reviewed_at=reviewed_at,
+            reviewer_id=10,
+        )
+
+        assert politician.id == 1
+        assert politician.name == "山田太郎"
+        assert politician.party_id == 1
+        assert politician.district == "東京1区"
+        assert politician.position == "衆議院議員"
+        assert politician.profile_url == "https://example.com/profile"
+        assert politician.image_url == "https://example.com/image.jpg"
+        assert politician.status == "approved"
+        assert politician.extracted_at == extracted_at
+        assert politician.reviewed_at == reviewed_at
+        assert politician.reviewer_id == 10
+
+    def test_is_pending_method(self) -> None:
+        """Test is_pending method with different statuses."""
+        # Test with pending status
+        pending_politician = create_extracted_politician(status="pending")
+        assert pending_politician.is_pending() is True
+
+        # Test with reviewed status
+        reviewed_politician = create_extracted_politician(status="reviewed")
+        assert reviewed_politician.is_pending() is False
+
+        # Test with approved status
+        approved_politician = create_extracted_politician(status="approved")
+        assert approved_politician.is_pending() is False
+
+        # Test with rejected status
+        rejected_politician = create_extracted_politician(status="rejected")
+        assert rejected_politician.is_pending() is False
+
+    def test_is_reviewed_method(self) -> None:
+        """Test is_reviewed method with different statuses."""
+        # Test with reviewed status
+        reviewed_politician = create_extracted_politician(status="reviewed")
+        assert reviewed_politician.is_reviewed() is True
+
+        # Test with pending status
+        pending_politician = create_extracted_politician(status="pending")
+        assert pending_politician.is_reviewed() is False
+
+        # Test with approved status
+        approved_politician = create_extracted_politician(status="approved")
+        assert approved_politician.is_reviewed() is False
+
+        # Test with rejected status
+        rejected_politician = create_extracted_politician(status="rejected")
+        assert rejected_politician.is_reviewed() is False
+
+    def test_is_approved_method(self) -> None:
+        """Test is_approved method with different statuses."""
+        # Test with approved status
+        approved_politician = create_extracted_politician(status="approved")
+        assert approved_politician.is_approved() is True
+
+        # Test with pending status
+        pending_politician = create_extracted_politician(status="pending")
+        assert pending_politician.is_approved() is False
+
+        # Test with reviewed status
+        reviewed_politician = create_extracted_politician(status="reviewed")
+        assert reviewed_politician.is_approved() is False
+
+        # Test with rejected status
+        rejected_politician = create_extracted_politician(status="rejected")
+        assert rejected_politician.is_approved() is False
+
+    def test_is_rejected_method(self) -> None:
+        """Test is_rejected method with different statuses."""
+        # Test with rejected status
+        rejected_politician = create_extracted_politician(status="rejected")
+        assert rejected_politician.is_rejected() is True
+
+        # Test with pending status
+        pending_politician = create_extracted_politician(status="pending")
+        assert pending_politician.is_rejected() is False
+
+        # Test with reviewed status
+        reviewed_politician = create_extracted_politician(status="reviewed")
+        assert reviewed_politician.is_rejected() is False
+
+        # Test with approved status
+        approved_politician = create_extracted_politician(status="approved")
+        assert approved_politician.is_rejected() is False
+
+    def test_mark_as_reviewed(self) -> None:
+        """Test mark_as_reviewed method."""
+        politician = create_extracted_politician(status="pending")
+        assert politician.status == "pending"
+        assert politician.reviewed_at is None
+        assert politician.reviewer_id is None
+
+        before = datetime.now()
+        politician.mark_as_reviewed(reviewer_id=5)
+        after = datetime.now()
+
+        assert politician.status == "reviewed"
+        assert politician.reviewed_at is not None
+        assert before <= politician.reviewed_at <= after
+        assert politician.reviewer_id == 5
+
+    def test_approve_method(self) -> None:
+        """Test approve method."""
+        politician = create_extracted_politician(status="pending")
+        assert politician.status == "pending"
+        assert politician.reviewed_at is None
+        assert politician.reviewer_id is None
+
+        before = datetime.now()
+        politician.approve(reviewer_id=3)
+        after = datetime.now()
+
+        assert politician.status == "approved"
+        assert politician.reviewed_at is not None
+        assert before <= politician.reviewed_at <= after
+        assert politician.reviewer_id == 3
+
+    def test_reject_method(self) -> None:
+        """Test reject method."""
+        politician = create_extracted_politician(status="pending")
+        assert politician.status == "pending"
+        assert politician.reviewed_at is None
+        assert politician.reviewer_id is None
+
+        before = datetime.now()
+        politician.reject(reviewer_id=7)
+        after = datetime.now()
+
+        assert politician.status == "rejected"
+        assert politician.reviewed_at is not None
+        assert before <= politician.reviewed_at <= after
+        assert politician.reviewer_id == 7
+
+    def test_str_representation(self) -> None:
+        """Test string representation of the entity."""
+        politician = create_extracted_politician(name="鈴木一郎", status="approved")
+
+        expected = "ExtractedPolitician(name=鈴木一郎, status=approved)"
+        assert str(politician) == expected
+
+    def test_different_statuses(self) -> None:
+        """Test entity with different statuses."""
+        statuses = ["pending", "reviewed", "approved", "rejected"]
+
+        for status in statuses:
+            politician = create_extracted_politician(status=status)
+            assert politician.status == status
+
+    def test_entity_factory(self) -> None:
+        """Test entity creation using factory."""
+        politician = create_extracted_politician()
+
+        assert politician.id == 1
+        assert politician.name == "山田太郎"
+        assert politician.party_id == 1
+        assert politician.district == "東京1区"
+        assert politician.position == "衆議院議員"
+        assert politician.profile_url == "https://example.com/profile"
+        assert politician.image_url == "https://example.com/image.jpg"
+        assert politician.status == "pending"
+
+    def test_factory_with_overrides(self) -> None:
+        """Test entity factory with custom values."""
+        politician = create_extracted_politician(
+            id=99,
+            name="佐藤花子",
+            status="approved",
+            party_id=3,
+            district="大阪1区",
+        )
+
+        assert politician.id == 99
+        assert politician.name == "佐藤花子"
+        assert politician.status == "approved"
+        assert politician.party_id == 3
+        assert politician.district == "大阪1区"
+        # Verify defaults are still applied
+        assert politician.position == "衆議院議員"
+        assert politician.profile_url == "https://example.com/profile"
+
+    def test_extracted_at_default_value(self) -> None:
+        """Test that extracted_at is set to current time by default."""
+        before = datetime.now()
+        politician = ExtractedPolitician(name="Test")
+        after = datetime.now()
+
+        assert before <= politician.extracted_at <= after
+
+    def test_politician_with_party_affiliation(self) -> None:
+        """Test a politician with party affiliation."""
+        politician = create_extracted_politician(
+            name="田中次郎",
+            party_id=2,
+            district="京都2区",
+            position="参議院議員",
+        )
+
+        assert politician.name == "田中次郎"
+        assert politician.party_id == 2
+        assert politician.district == "京都2区"
+        assert politician.position == "参議院議員"
+
+    def test_politician_without_party_affiliation(self) -> None:
+        """Test a politician without party affiliation (independent)."""
+        politician = create_extracted_politician(
+            name="独立太郎",
+            party_id=None,
+            district="無所属",
+        )
+
+        assert politician.name == "独立太郎"
+        assert politician.party_id is None
+        assert politician.district == "無所属"
+
+    def test_status_change_workflow(self) -> None:
+        """Test the workflow of status changes."""
+        politician = create_extracted_politician(status="pending")
+
+        # Initially pending
+        assert politician.is_pending() is True
+        assert politician.is_reviewed() is False
+        assert politician.is_approved() is False
+        assert politician.is_rejected() is False
+
+        # Mark as reviewed
+        politician.mark_as_reviewed(reviewer_id=1)
+        assert politician.is_pending() is False
+        assert politician.is_reviewed() is True
+        assert politician.is_approved() is False
+        assert politician.is_rejected() is False
+
+        # Approve
+        politician.approve(reviewer_id=1)
+        assert politician.is_pending() is False
+        assert politician.is_reviewed() is False
+        assert politician.is_approved() is True
+        assert politician.is_rejected() is False

--- a/tests/fixtures/entity_factories.py
+++ b/tests/fixtures/entity_factories.py
@@ -6,6 +6,7 @@ from typing import Any
 from src.domain.entities.conference import Conference
 from src.domain.entities.conversation import Conversation
 from src.domain.entities.extracted_conference_member import ExtractedConferenceMember
+from src.domain.entities.extracted_politician import ExtractedPolitician
 from src.domain.entities.extracted_proposal_judge import ExtractedProposalJudge
 from src.domain.entities.governing_body import GoverningBody
 from src.domain.entities.meeting import Meeting
@@ -100,6 +101,25 @@ def create_politician(**kwargs: Any) -> Politician:
     }
     defaults.update(kwargs)
     return Politician(**defaults)
+
+
+def create_extracted_politician(**kwargs: Any) -> ExtractedPolitician:
+    """Create a test extracted politician."""
+    defaults = {
+        "id": 1,
+        "name": "山田太郎",
+        "party_id": 1,
+        "district": "東京1区",
+        "position": "衆議院議員",
+        "profile_url": "https://example.com/profile",
+        "image_url": "https://example.com/image.jpg",
+        "status": "pending",
+        "extracted_at": datetime.now(),
+        "reviewed_at": None,
+        "reviewer_id": None,
+    }
+    defaults.update(kwargs)
+    return ExtractedPolitician(**defaults)
 
 
 def create_political_party(**kwargs: Any) -> PoliticalParty:

--- a/tests/infrastructure/persistence/test_extracted_politician_repository_impl.py
+++ b/tests/infrastructure/persistence/test_extracted_politician_repository_impl.py
@@ -1,0 +1,448 @@
+"""Tests for ExtractedPoliticianRepositoryImpl."""
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.entities.extracted_politician import ExtractedPolitician
+from src.infrastructure.persistence.extracted_politician_repository_impl import (
+    ExtractedPoliticianModel,
+    ExtractedPoliticianRepositoryImpl,
+)
+
+
+class TestExtractedPoliticianRepositoryImpl:
+    """Test cases for ExtractedPoliticianRepositoryImpl."""
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock session."""
+        session = MagicMock(spec=AsyncSession)
+        return session
+
+    @pytest.fixture
+    def repository(self, mock_session: MagicMock) -> ExtractedPoliticianRepositoryImpl:
+        """Create extracted politician repository."""
+        return ExtractedPoliticianRepositoryImpl(mock_session)
+
+    def _create_mock_row(self, **kwargs: Any) -> MagicMock:
+        """Create a mock database row."""
+        defaults = {
+            "id": 1,
+            "name": "山田太郎",
+            "party_id": 1,
+            "district": "東京1区",
+            "position": "衆議院議員",
+            "profile_url": "https://example.com/profile",
+            "image_url": "https://example.com/image.jpg",
+            "status": "pending",
+            "extracted_at": datetime(2023, 1, 1),
+            "reviewed_at": None,
+            "reviewer_id": None,
+        }
+        defaults.update(kwargs)
+
+        mock_row = MagicMock()
+        mock_row._mapping = defaults
+        for key, value in defaults.items():
+            setattr(mock_row, key, value)
+        return mock_row
+
+    @pytest.mark.asyncio
+    async def test_get_pending_without_party_id(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test get_pending without party_id filter."""
+        # Setup
+        mock_rows = [
+            self._create_mock_row(id=1, status="pending"),
+            self._create_mock_row(id=2, status="pending", party_id=2),
+        ]
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = mock_rows
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            return mock_result
+
+        mock_session.execute = async_execute
+
+        # Execute
+        result = await repository.get_pending()
+
+        # Verify
+        assert len(result) == 2
+        assert all(p.status == "pending" for p in result)
+        assert result[0].id == 1
+        assert result[1].id == 2
+
+    @pytest.mark.asyncio
+    async def test_get_pending_with_party_id(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test get_pending with party_id filter."""
+        # Setup
+        mock_rows = [
+            self._create_mock_row(id=1, status="pending", party_id=1),
+        ]
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = mock_rows
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            return mock_result
+
+        mock_session.execute = async_execute
+
+        # Execute
+        result = await repository.get_pending(party_id=1)
+
+        # Verify
+        assert len(result) == 1
+        assert result[0].id == 1
+        assert result[0].party_id == 1
+        assert result[0].status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_get_by_status(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test get_by_status method."""
+        # Setup
+        mock_rows = [
+            self._create_mock_row(id=1, status="approved"),
+            self._create_mock_row(id=2, status="approved", name="鈴木一郎"),
+        ]
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = mock_rows
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            return mock_result
+
+        mock_session.execute = async_execute
+
+        # Execute
+        result = await repository.get_by_status("approved")
+
+        # Verify
+        assert len(result) == 2
+        assert all(p.status == "approved" for p in result)
+        assert result[0].id == 1
+        assert result[1].name == "鈴木一郎"
+
+    @pytest.mark.asyncio
+    async def test_get_by_party(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test get_by_party method."""
+        # Setup
+        mock_rows = [
+            self._create_mock_row(id=1, party_id=2, name="佐藤太郎"),
+            self._create_mock_row(id=2, party_id=2, name="田中花子"),
+        ]
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = mock_rows
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            return mock_result
+
+        mock_session.execute = async_execute
+
+        # Execute
+        result = await repository.get_by_party(2)
+
+        # Verify
+        assert len(result) == 2
+        assert all(p.party_id == 2 for p in result)
+        assert result[0].name == "佐藤太郎"
+        assert result[1].name == "田中花子"
+
+    @pytest.mark.asyncio
+    async def test_update_status_to_approved(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test update_status to approved status."""
+        # Setup
+        reviewed_at = datetime.now()
+        updated_row = self._create_mock_row(
+            id=1,
+            status="approved",
+            reviewed_at=reviewed_at,
+            reviewer_id=5,
+        )
+
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = updated_row
+
+        execute_count = 0
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            nonlocal execute_count
+            execute_count += 1
+            if execute_count == 2:  # Second call is for get_by_id
+                return mock_result
+            return MagicMock()
+
+        mock_session.execute = async_execute
+
+        async def async_commit() -> None:
+            return None
+
+        mock_session.commit = async_commit
+
+        async def async_get(
+            model_class: Any, entity_id: Any
+        ) -> ExtractedPoliticianModel:
+            return ExtractedPoliticianModel(
+                id=1,
+                name="山田太郎",
+                party_id=1,
+                district="東京1区",
+                position="衆議院議員",
+                profile_url="https://example.com/profile",
+                image_url="https://example.com/image.jpg",
+                status="approved",
+                extracted_at=datetime(2023, 1, 1),
+                reviewed_at=reviewed_at,
+                reviewer_id=5,
+            )
+
+        mock_session.get = async_get
+
+        # Execute
+        result = await repository.update_status(1, "approved", reviewer_id=5)
+
+        # Verify
+        assert result is not None
+        assert result.id == 1
+        assert result.status == "approved"
+        assert result.reviewed_at == reviewed_at
+        assert result.reviewer_id == 5
+
+    @pytest.mark.asyncio
+    async def test_update_status_to_pending(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test update_status to pending status (should clear reviewer info)."""
+        # Setup
+        updated_row = self._create_mock_row(
+            id=1,
+            status="pending",
+            reviewed_at=None,
+            reviewer_id=None,
+        )
+
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = updated_row
+
+        execute_count = 0
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            nonlocal execute_count
+            execute_count += 1
+            if execute_count == 2:  # Second call is for get_by_id
+                return mock_result
+            return MagicMock()
+
+        mock_session.execute = async_execute
+
+        async def async_commit() -> None:
+            return None
+
+        mock_session.commit = async_commit
+
+        async def async_get(
+            model_class: Any, entity_id: Any
+        ) -> ExtractedPoliticianModel:
+            return ExtractedPoliticianModel(
+                id=1,
+                name="山田太郎",
+                party_id=1,
+                district="東京1区",
+                position="衆議院議員",
+                profile_url="https://example.com/profile",
+                image_url="https://example.com/image.jpg",
+                status="pending",
+                extracted_at=datetime(2023, 1, 1),
+                reviewed_at=None,
+                reviewer_id=None,
+            )
+
+        mock_session.get = async_get
+
+        # Execute
+        result = await repository.update_status(1, "pending")
+
+        # Verify
+        assert result is not None
+        assert result.id == 1
+        assert result.status == "pending"
+        assert result.reviewed_at is None
+        assert result.reviewer_id is None
+
+    @pytest.mark.asyncio
+    async def test_get_summary_by_status(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test get_summary_by_status method."""
+        # Setup
+        mock_rows = [
+            MagicMock(status="pending", count=5),
+            MagicMock(status="approved", count=3),
+            MagicMock(status="rejected", count=1),
+        ]
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = mock_rows
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            return mock_result
+
+        mock_session.execute = async_execute
+
+        # Execute
+        result = await repository.get_summary_by_status()
+
+        # Verify
+        assert result["pending"] == 5
+        assert result["approved"] == 3
+        assert result["rejected"] == 1
+        assert result["reviewed"] == 0
+        assert result["total"] == 9  # 5 + 3 + 1
+
+    @pytest.mark.asyncio
+    async def test_bulk_create(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test bulk_create method."""
+        # Setup
+        politicians = [
+            ExtractedPolitician(name="山田太郎", party_id=1),
+            ExtractedPolitician(name="鈴木花子", party_id=2),
+        ]
+
+        # Mock add_all and refresh
+        mock_session.add_all = MagicMock()
+
+        async def async_commit() -> None:
+            return None
+
+        mock_commit = MagicMock(side_effect=async_commit)
+        mock_session.commit = mock_commit
+
+        async def async_refresh(model: Any) -> None:
+            model.id = 1 if model.name == "山田太郎" else 2
+
+        mock_session.refresh = async_refresh
+
+        # Execute
+        result = await repository.bulk_create(politicians)
+
+        # Verify
+        assert len(result) == 2
+        assert result[0].name == "山田太郎"
+        assert result[1].name == "鈴木花子"
+        mock_session.add_all.assert_called_once()
+        mock_commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_duplicates_with_party_id(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test get_duplicates with party_id filter."""
+        # Setup
+        mock_rows = [
+            self._create_mock_row(id=1, name="山田太郎", party_id=1),
+            self._create_mock_row(id=2, name="山田太郎", party_id=1),
+        ]
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = mock_rows
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            return mock_result
+
+        mock_session.execute = async_execute
+
+        # Execute
+        result = await repository.get_duplicates("山田太郎", party_id=1)
+
+        # Verify
+        assert len(result) == 2
+        assert all(p.name == "山田太郎" for p in result)
+        assert all(p.party_id == 1 for p in result)
+
+    @pytest.mark.asyncio
+    async def test_get_duplicates_without_party_id(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test get_duplicates without party_id filter."""
+        # Setup
+        mock_rows = [
+            self._create_mock_row(id=1, name="山田太郎", party_id=1),
+            self._create_mock_row(id=2, name="山田太郎", party_id=2),
+            self._create_mock_row(id=3, name="山田太郎", party_id=None),
+        ]
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = mock_rows
+
+        async def async_execute(query: Any, params: Any = None) -> MagicMock:
+            return mock_result
+
+        mock_session.execute = async_execute
+
+        # Execute
+        result = await repository.get_duplicates("山田太郎")
+
+        # Verify
+        assert len(result) == 3
+        assert all(p.name == "山田太郎" for p in result)
+        assert result[0].party_id == 1
+        assert result[1].party_id == 2
+        assert result[2].party_id is None
+
+    @pytest.mark.asyncio
+    async def test_row_to_entity_conversion(
+        self, repository: ExtractedPoliticianRepositoryImpl, mock_session: MagicMock
+    ) -> None:
+        """Test conversion from database row to domain entity."""
+        # Setup
+        extracted_at = datetime(2023, 1, 1, 12, 0, 0)
+        reviewed_at = datetime(2023, 1, 2, 12, 0, 0)
+
+        mock_row = self._create_mock_row(
+            id=99,
+            name="テスト政治家",
+            party_id=3,
+            district="大阪1区",
+            position="参議院議員",
+            profile_url="https://test.com/profile",
+            image_url="https://test.com/image.jpg",
+            status="reviewed",
+            extracted_at=extracted_at,
+            reviewed_at=reviewed_at,
+            reviewer_id=10,
+        )
+
+        # Execute
+        entity = repository._row_to_entity(mock_row)  # type: ignore[attr-defined]
+
+        # Verify
+        assert isinstance(entity, ExtractedPolitician)
+        assert entity.id == 99
+        assert entity.name == "テスト政治家"
+        assert entity.party_id == 3
+        assert entity.district == "大阪1区"
+        assert entity.position == "参議院議員"
+        assert entity.profile_url == "https://test.com/profile"
+        assert entity.image_url == "https://test.com/image.jpg"
+        assert entity.status == "reviewed"
+        assert entity.extracted_at == extracted_at
+        assert entity.reviewed_at == reviewed_at
+        assert entity.reviewer_id == 10


### PR DESCRIPTION
## 概要
ExtractedPoliticianエンティティとリポジトリを実装しました。政治家データの中間オブジェクトとして、LLMが抽出した政治家データを人間がレビューする前の状態を管理します。

## 実装内容
### エンティティ (`src/domain/entities/extracted_politician.py`)
- ✅ 基本情報フィールド（name, party_id）
- ✅ 詳細情報フィールド（district, position, profile_url, image_url）
- ✅ ステータス管理（pending/reviewed/approved/rejected）
- ✅ メタデータ（extracted_at, reviewed_at, reviewer_id）
- ✅ ステータス操作メソッド（`mark_as_reviewed()`, `approve()`, `reject()`）
- ✅ ステータス確認メソッド（`is_pending()`, `is_reviewed()`, `is_approved()`, `is_rejected()`）

### リポジトリインターフェース (`src/domain/repositories/extracted_politician_repository.py`)
- ✅ 基本CRUD操作
- ✅ ステータス別検索（`get_pending()`, `get_by_status()`）
- ✅ 政党別検索（`get_by_party()`）
- ✅ ステータス更新（`update_status()`）
- ✅ 統計情報取得（`get_summary_by_status()`）
- ✅ 一括登録（`bulk_create()`）
- ✅ 重複検出（`get_duplicates()`）

### リポジトリ実装 (`src/infrastructure/persistence/extracted_politician_repository_impl.py`)
- ✅ SQLAlchemyを使用した実装
- ✅ 非同期処理対応
- ✅ 動的モデル定義（ExtractedPoliticianModel）

### テスト
- ✅ エンティティテスト: 17テストケース（`tests/domain/entities/test_extracted_politician.py`）
- ✅ リポジトリテスト: 11テストケース（`tests/infrastructure/persistence/test_extracted_politician_repository_impl.py`）
- ✅ テストファクトリー追加（`tests/fixtures/entity_factories.py`）

## テスト結果
```
============================== 28 passed in 0.15s ==============================
```

## コード品質
- ✅ Ruff format: 合格
- ✅ Ruff check: 合格  
- ✅ Pyright: 合格

## 受入条件の達成状況
- [x] ExtractedPoliticianエンティティがドメイン層に定義されている
- [x] IExtractedPoliticianRepositoryインターフェースが定義されている
- [x] ExtractedPoliticianRepositoryImplが実装されている
- [x] エンティティには全ての必須フィールドが含まれている
- [x] 単体テストが実装されている

## 関連Issue
Fixes #513

🤖 Generated with Claude Code