### PR TITLE
[PBI-003] 政党ページ抽出処理のextracted_politicians対応

### DIFF
--- a/src/application/dtos/politician_dto.py
+++ b/src/application/dtos/politician_dto.py
@@ -68,3 +68,18 @@ class ScrapePoliticiansInputDTO:
     party_id: int | None = None
     all_parties: bool = False
     dry_run: bool = False
+
+
+@dataclass
+class ExtractedPoliticianOutputDTO:
+    """DTO for extracted politician output."""
+
+    id: int
+    name: str
+    party_id: int | None
+    party_name: str | None
+    district: str | None
+    position: str | None
+    profile_url: str | None
+    image_url: str | None
+    status: str

--- a/src/infrastructure/di/providers.py
+++ b/src/infrastructure/di/providers.py
@@ -35,6 +35,9 @@ from src.infrastructure.persistence.conversation_repository_impl import (
 from src.infrastructure.persistence.extracted_conference_member_repository_impl import (
     ExtractedConferenceMemberRepositoryImpl,
 )
+from src.infrastructure.persistence.extracted_politician_repository_impl import (
+    ExtractedPoliticianRepositoryImpl,
+)
 from src.infrastructure.persistence.extracted_proposal_judge_repository_impl import (
     ExtractedProposalJudgeRepositoryImpl,
 )
@@ -246,6 +249,11 @@ class RepositoryContainer(containers.DeclarativeContainer):
         session=database.async_session,
     )
 
+    extracted_politician_repository = providers.Factory(
+        ExtractedPoliticianRepositoryImpl,
+        session=database.async_session,
+    )
+
     extracted_proposal_judge_repository = providers.Factory(
         ExtractedProposalJudgeRepositoryImpl,
         session=database.async_session,
@@ -344,9 +352,7 @@ class UseCaseContainer(containers.DeclarativeContainer):
     scrape_politicians_usecase = providers.Factory(
         ScrapePoliticiansUseCase,
         political_party_repository=repositories.political_party_repository,
-        politician_repository=repositories.politician_repository,
-        speaker_repository=repositories.speaker_repository,
-        politician_domain_service=services.politician_domain_service,
+        extracted_politician_repository=repositories.extracted_politician_repository,
         web_scraper_service=services.web_scraper_service,
     )
 


### PR DESCRIPTION
## 概要
Issue #515 の実装です。政党ページから抽出した政治家データを、直接politiciansテーブルに保存するのではなく、中間テーブル（extracted_politicians）に保存するよう変更しました。これにより、人間によるレビューを経てから本番データとして承認できるようになります。

## 変更内容
### 主要な変更
- `ScrapePoliticiansUseCase`を中間テーブル（extracted_politicians）を使用するよう変更
- 新しい`ExtractedPoliticianOutputDTO`を追加し、適切なデータ転送を実現
- 重複チェックロジックをextracted_politiciansテーブル内で実施するよう修正

### 技術的変更
- 依存関係を`PoliticianRepository`/`SpeakerRepository`から`ExtractedPoliticianRepository`に変更
- 返り値の型を`list[PoliticianDTO]`から`list[ExtractedPoliticianOutputDTO]`に変更
- テストを新しい実装に合わせて更新

## 受入条件の達成状況
- ✅ ScrapePoliticiansUseCaseがextracted_politiciansテーブルにデータを保存するように修正されている
- ✅ PartyMemberExtractorServiceの戻り値がExtractedPoliticianエンティティに対応している
- ✅ 重複チェックロジックがextracted_politiciansテーブルを参照するように修正されている
- ✅ 既存のテストが新しい実装に対応している（全8テスト成功）
- ✅ ドライランモードが正常に動作する

## テスト結果
```
============================== 8 passed in 0.85s ===============================
```
全てのテストが成功しています。

## アーキテクチャレビュー結果
PR architecture reviewerによる詳細なレビューを実施済み：
- ✅ Clean Architecture準拠
- ✅ 適切な責任分離とDTO使用
- ✅ 包括的なテストカバレッジ
- ✅ 非同期処理の一貫した使用

## 関連Issue
Fixes #515

🤖 Generated with Claude Code