### PR TITLE
[PBI-004] extracted_politiciansからpoliticiansへの変換ユースケース実装

### DIFF
--- a/database/02_run_migrations.sql
+++ b/database/02_run_migrations.sql
@@ -30,5 +30,6 @@
 \i /docker-entrypoint-initdb.d/02_migrations/025_create_proposal_parliamentary_group_judges.sql
 \i /docker-entrypoint-initdb.d/02_migrations/026_create_extracted_politicians_table.sql
 \i /docker-entrypoint-initdb.d/02_migrations/027_migrate_existing_politicians.sql
+\i /docker-entrypoint-initdb.d/02_migrations/028_add_converted_status_to_extracted_politicians.sql
 
 \echo 'Migrations completed.'

--- a/database/migrations/028_add_converted_status_to_extracted_politicians.sql
+++ b/database/migrations/028_add_converted_status_to_extracted_politicians.sql
@@ -1,0 +1,10 @@
+-- Add 'converted' as a valid status for extracted_politicians table
+
+-- Drop the existing check constraint
+ALTER TABLE extracted_politicians DROP CONSTRAINT IF EXISTS check_status;
+
+-- Add the new check constraint with 'converted' status
+ALTER TABLE extracted_politicians
+ADD CONSTRAINT check_status CHECK (
+    status IN ('pending', 'reviewed', 'approved', 'rejected', 'converted')
+);

--- a/src/application/dtos/convert_extracted_politician_dto.py
+++ b/src/application/dtos/convert_extracted_politician_dto.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ConvertExtractedPoliticianInputDTO:
+    """変換対象の抽出済み政治家を指定する入力DTO"""
+
+    party_id: int | None = None
+    batch_size: int = 100
+    dry_run: bool = False
+
+
+@dataclass
+class ConvertedPoliticianDTO:
+    """変換された政治家情報を表すDTO"""
+
+    politician_id: int
+    name: str
+    party_id: int | None
+    district: str | None
+    position: str | None
+    speaker_id: int
+    profile_url: str | None
+    image_url: str | None
+
+
+@dataclass
+class ConvertExtractedPoliticianOutputDTO:
+    """変換結果を表す出力DTO"""
+
+    total_processed: int
+    converted_count: int
+    skipped_count: int
+    error_count: int
+    converted_politicians: list[ConvertedPoliticianDTO]
+    skipped_names: list[str]
+    error_messages: list[str]

--- a/src/application/usecases/convert_extracted_politician_usecase.py
+++ b/src/application/usecases/convert_extracted_politician_usecase.py
@@ -1,0 +1,299 @@
+import logging
+from typing import Any
+
+from src.application.dtos.convert_extracted_politician_dto import (
+    ConvertedPoliticianDTO,
+    ConvertExtractedPoliticianInputDTO,
+    ConvertExtractedPoliticianOutputDTO,
+)
+from src.domain.entities.politician import Politician
+from src.domain.entities.speaker import Speaker
+from src.domain.repositories.extracted_politician_repository import (
+    ExtractedPoliticianRepository,
+)
+from src.domain.repositories.politician_repository import PoliticianRepository
+from src.domain.repositories.speaker_repository import SpeakerRepository
+
+logger = logging.getLogger(__name__)
+
+
+class ConvertExtractedPoliticianUseCase:
+    """抽出済み政治家を正式な政治家データに変換するユースケース
+
+    extracted_politiciansテーブルのapproved状態のレコードを
+    politicians/speakersテーブルに変換します。
+
+    Attributes:
+        extracted_politician_repo: 抽出済み政治家リポジトリ
+        politician_repo: 政治家リポジトリ
+        speaker_repo: スピーカーリポジトリ
+
+    Example:
+        >>> use_case = ConvertExtractedPoliticianUseCase(
+        ...     extracted_politician_repo, politician_repo, speaker_repo
+        ... )
+        >>> # 全approvedレコードを変換
+        >>> result = await use_case.execute(
+        ...     ConvertExtractedPoliticianInputDTO()
+        ... )
+        >>> print(f"変換成功: {result.converted_count}件")
+
+        >>> # 特定政党のレコードのみ変換（ドライラン）
+        >>> result = await use_case.execute(
+        ...     ConvertExtractedPoliticianInputDTO(party_id=5, dry_run=True)
+        ... )
+    """
+
+    def __init__(
+        self,
+        extracted_politician_repository: ExtractedPoliticianRepository,
+        politician_repository: PoliticianRepository,
+        speaker_repository: SpeakerRepository,
+    ):
+        """変換ユースケースを初期化する
+
+        Args:
+            extracted_politician_repository: 抽出済み政治家リポジトリの実装
+            politician_repository: 政治家リポジトリの実装
+            speaker_repository: スピーカーリポジトリの実装
+        """
+        self.extracted_politician_repo = extracted_politician_repository
+        self.politician_repo = politician_repository
+        self.speaker_repo = speaker_repository
+
+    async def execute(
+        self,
+        request: ConvertExtractedPoliticianInputDTO,
+    ) -> ConvertExtractedPoliticianOutputDTO:
+        """抽出済み政治家の変換を実行する
+
+        処理の流れ：
+        1. approved状態のextracted_politiciansを取得
+        2. 各レコードについて：
+           - 対応するSpeakerを作成または取得
+           - 対応するPoliticianを作成または更新
+           - extracted_politicianのstatusをconvertedに更新
+        3. 結果をまとめて返却
+
+        Args:
+            request: 変換リクエストDTO
+                - party_id: 特定政党のみ対象とする場合のID（オプション）
+                - batch_size: バッチサイズ（デフォルト100）
+                - dry_run: 実行せずに結果を確認するか
+
+        Returns:
+            ConvertExtractedPoliticianOutputDTO:
+            - total_processed: 処理対象件数
+            - converted_count: 変換成功件数
+            - skipped_count: スキップ件数
+            - error_count: エラー件数
+            - converted_politicians: 変換された政治家情報
+            - skipped_names: スキップされた政治家名
+            - error_messages: エラーメッセージ
+
+        Raises:
+            ValueError: 無効なパラメータが指定された場合
+        """
+        # Get approved extracted politicians
+        approved_politicians = await self.extracted_politician_repo.get_by_status(
+            "approved"
+        )
+
+        # Filter by party if specified
+        if request.party_id:
+            approved_politicians = [
+                p for p in approved_politicians if p.party_id == request.party_id
+            ]
+
+        # Apply batch size limit
+        if len(approved_politicians) > request.batch_size:
+            approved_politicians = approved_politicians[: request.batch_size]
+
+        total_processed = len(approved_politicians)
+        converted_politicians: list[ConvertedPoliticianDTO] = []
+        skipped_names: list[str] = []
+        error_messages: list[str] = []
+
+        logger.info(f"Processing {total_processed} approved extracted politicians")
+
+        for extracted in approved_politicians:
+            try:
+                if request.dry_run:
+                    # Dry run - just check without actual conversion
+                    # Check for existing politician
+                    existing = await self.politician_repo.get_by_name_and_party(
+                        extracted.name, extracted.party_id
+                    )
+                    if existing:
+                        logger.info(
+                            f"[DRY RUN] Would update existing politician: "
+                            f"{extracted.name}"
+                        )
+                    else:
+                        logger.info(
+                            f"[DRY RUN] Would create new politician: {extracted.name}"
+                        )
+
+                    # Mock converted politician for dry run
+                    converted_politicians.append(
+                        ConvertedPoliticianDTO(
+                            politician_id=existing.id
+                            if existing and existing.id
+                            else 0,
+                            name=extracted.name,
+                            party_id=extracted.party_id,
+                            district=extracted.district,
+                            position=extracted.position,
+                            speaker_id=0,  # Mock speaker ID for dry run
+                            profile_url=extracted.profile_url,
+                            image_url=extracted.image_url,
+                        )
+                    )
+                else:
+                    # Actual conversion
+                    politician = await self._convert_to_politician(extracted)
+                    if politician:
+                        converted_politicians.append(
+                            ConvertedPoliticianDTO(
+                                politician_id=politician.id if politician.id else 0,
+                                name=politician.name,
+                                party_id=politician.political_party_id,
+                                district=politician.district,
+                                position=politician.position,
+                                speaker_id=politician.speaker_id,
+                                profile_url=politician.profile_page_url,
+                                image_url=politician.profile_image_url,
+                            )
+                        )
+
+                        # Update extracted politician status to converted
+                        await self.extracted_politician_repo.update_status(
+                            extracted.id if extracted.id else 0,
+                            "converted",
+                        )
+                        logger.info(
+                            f"Successfully converted politician: {politician.name}"
+                        )
+                    else:
+                        skipped_names.append(extracted.name)
+                        logger.warning(f"Skipped politician: {extracted.name}")
+
+            except Exception as e:
+                error_messages.append(f"Error converting {extracted.name}: {str(e)}")
+                logger.error(f"Error converting {extracted.name}: {e}")
+
+        # Calculate final counts
+        converted_count = len(converted_politicians)
+        skipped_count = len(skipped_names)
+        error_count = len(error_messages)
+
+        logger.info(
+            f"Conversion complete - Converted: {converted_count}, "
+            f"Skipped: {skipped_count}, Errors: {error_count}"
+        )
+
+        return ConvertExtractedPoliticianOutputDTO(
+            total_processed=total_processed,
+            converted_count=converted_count,
+            skipped_count=skipped_count,
+            error_count=error_count,
+            converted_politicians=converted_politicians,
+            skipped_names=skipped_names,
+            error_messages=error_messages,
+        )
+
+    async def _convert_to_politician(self, extracted: Any) -> Politician | None:
+        """抽出済み政治家を正式な政治家に変換する
+
+        Args:
+            extracted: ExtractedPoliticianエンティティ
+
+        Returns:
+            変換されたPoliticianエンティティ、変換できない場合はNone
+
+        Raises:
+            Exception: スピーカー作成に失敗した場合
+        """
+        try:
+            # Create or get speaker
+            speaker = await self._get_or_create_speaker(extracted)
+            if not speaker or not speaker.id:
+                logger.error(f"Failed to create speaker for {extracted.name}")
+                raise Exception(f"Failed to create speaker for {extracted.name}")
+
+            # Check for existing politician
+            existing_politician = await self.politician_repo.get_by_name_and_party(
+                extracted.name, extracted.party_id
+            )
+
+            if existing_politician:
+                # Update existing politician
+                existing_politician.district = (
+                    extracted.district or existing_politician.district
+                )
+                existing_politician.position = (
+                    extracted.position or existing_politician.position
+                )
+                existing_politician.profile_page_url = (
+                    extracted.profile_url or existing_politician.profile_page_url
+                )
+                existing_politician.profile_image_url = (
+                    extracted.image_url or existing_politician.profile_image_url
+                )
+                politician = await self.politician_repo.update(existing_politician)
+                logger.info(f"Updated existing politician: {politician.name}")
+            else:
+                # Create new politician
+                politician = Politician(
+                    name=extracted.name,
+                    speaker_id=speaker.id,
+                    political_party_id=extracted.party_id,
+                    district=extracted.district,
+                    position=extracted.position,
+                    profile_page_url=extracted.profile_url,
+                    profile_image_url=extracted.image_url,
+                )
+                politician = await self.politician_repo.create(politician)
+                logger.info(f"Created new politician: {politician.name}")
+
+            return politician
+
+        except Exception as e:
+            logger.error(f"Error converting {extracted.name}: {e}")
+            raise  # Re-raise exception to be caught by caller
+
+    async def _get_or_create_speaker(self, extracted: Any) -> Speaker | None:
+        """抽出済み政治家に対応するスピーカーを取得または作成する
+
+        Args:
+            extracted: ExtractedPoliticianエンティティ
+
+        Returns:
+            作成または取得されたSpeakerエンティティ
+        """
+        try:
+            # Check for existing speaker
+            existing_speaker = await self.speaker_repo.find_by_name(extracted.name)
+
+            if existing_speaker:
+                # Update speaker as politician if not already
+                if not existing_speaker.is_politician:
+                    existing_speaker.is_politician = True
+                    existing_speaker = await self.speaker_repo.update(existing_speaker)
+                return existing_speaker
+
+            # Create new speaker
+            speaker = Speaker(
+                name=extracted.name,
+                type="議員",
+                political_party_name=None,  # Will be set from party_id relation
+                position=extracted.position,
+                is_politician=True,
+            )
+            created_speaker = await self.speaker_repo.create(speaker)
+            logger.info(f"Created new speaker: {created_speaker.name}")
+            return created_speaker
+
+        except Exception as e:
+            logger.error(f"Error creating speaker for {extracted.name}: {e}")
+            return None

--- a/tests/application/usecases/test_convert_extracted_politician_usecase.py
+++ b/tests/application/usecases/test_convert_extracted_politician_usecase.py
@@ -1,0 +1,371 @@
+"""Tests for ConvertExtractedPoliticianUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.application.dtos.convert_extracted_politician_dto import (
+    ConvertExtractedPoliticianInputDTO,
+)
+from src.application.usecases.convert_extracted_politician_usecase import (
+    ConvertExtractedPoliticianUseCase,
+)
+from src.domain.entities.extracted_politician import ExtractedPolitician
+from src.domain.entities.politician import Politician
+from src.domain.entities.speaker import Speaker
+
+
+class TestConvertExtractedPoliticianUseCase:
+    """Test cases for ConvertExtractedPoliticianUseCase."""
+
+    @pytest.fixture
+    def mock_extracted_politician_repo(self):
+        """Create mock extracted politician repository."""
+        repo = AsyncMock()
+        return repo
+
+    @pytest.fixture
+    def mock_politician_repo(self):
+        """Create mock politician repository."""
+        repo = AsyncMock()
+        return repo
+
+    @pytest.fixture
+    def mock_speaker_repo(self):
+        """Create mock speaker repository."""
+        repo = AsyncMock()
+        return repo
+
+    @pytest.fixture
+    def use_case(
+        self,
+        mock_extracted_politician_repo,
+        mock_politician_repo,
+        mock_speaker_repo,
+    ):
+        """Create ConvertExtractedPoliticianUseCase instance."""
+        return ConvertExtractedPoliticianUseCase(
+            extracted_politician_repository=mock_extracted_politician_repo,
+            politician_repository=mock_politician_repo,
+            speaker_repository=mock_speaker_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_convert_approved_politicians(
+        self,
+        use_case,
+        mock_extracted_politician_repo,
+        mock_politician_repo,
+        mock_speaker_repo,
+    ):
+        """Test converting approved extracted politicians."""
+        # Setup
+        extracted_politicians = [
+            ExtractedPolitician(
+                id=1,
+                name="山田太郎",
+                party_id=1,
+                district="東京1区",
+                position="衆議院議員",
+                profile_url="https://example.com/yamada",
+                image_url="https://example.com/yamada.jpg",
+                status="approved",
+            ),
+            ExtractedPolitician(
+                id=2,
+                name="鈴木花子",
+                party_id=2,
+                district="大阪2区",
+                position="参議院議員",
+                profile_url="https://example.com/suzuki",
+                image_url="https://example.com/suzuki.jpg",
+                status="approved",
+            ),
+        ]
+
+        mock_extracted_politician_repo.get_by_status.return_value = (
+            extracted_politicians
+        )
+
+        # No existing politicians
+        mock_politician_repo.get_by_name_and_party.return_value = None
+
+        # Mock speaker creation/retrieval
+        mock_speaker_repo.find_by_name.return_value = None
+        mock_speaker_repo.create.side_effect = [
+            Speaker(id=1, name="山田太郎", is_politician=True),
+            Speaker(id=2, name="鈴木花子", is_politician=True),
+        ]
+
+        # Mock politician creation
+        mock_politician_repo.create.side_effect = [
+            Politician(
+                id=1,
+                name="山田太郎",
+                speaker_id=1,
+                political_party_id=1,
+                district="東京1区",
+                position="衆議院議員",
+                profile_page_url="https://example.com/yamada",
+                profile_image_url="https://example.com/yamada.jpg",
+            ),
+            Politician(
+                id=2,
+                name="鈴木花子",
+                speaker_id=2,
+                political_party_id=2,
+                district="大阪2区",
+                position="参議院議員",
+                profile_page_url="https://example.com/suzuki",
+                profile_image_url="https://example.com/suzuki.jpg",
+            ),
+        ]
+
+        # Execute
+        result = await use_case.execute(ConvertExtractedPoliticianInputDTO())
+
+        # Assertions
+        assert result.total_processed == 2
+        assert result.converted_count == 2
+        assert result.skipped_count == 0
+        assert result.error_count == 0
+        assert len(result.converted_politicians) == 2
+
+        # Verify first politician
+        assert result.converted_politicians[0].name == "山田太郎"
+        assert result.converted_politicians[0].politician_id == 1
+        assert result.converted_politicians[0].speaker_id == 1
+        assert result.converted_politicians[0].party_id == 1
+
+        # Verify status update was called
+        assert mock_extracted_politician_repo.update_status.call_count == 2
+        mock_extracted_politician_repo.update_status.assert_any_call(1, "converted")
+        mock_extracted_politician_repo.update_status.assert_any_call(2, "converted")
+
+    @pytest.mark.asyncio
+    async def test_update_existing_politician(
+        self,
+        use_case,
+        mock_extracted_politician_repo,
+        mock_politician_repo,
+        mock_speaker_repo,
+    ):
+        """Test updating existing politician when converting."""
+        # Setup
+        extracted = ExtractedPolitician(
+            id=1,
+            name="山田太郎",
+            party_id=1,
+            district="東京2区",  # Updated district
+            position="衆議院議員",
+            profile_url="https://example.com/yamada-new",
+            image_url="https://example.com/yamada-new.jpg",
+            status="approved",
+        )
+
+        mock_extracted_politician_repo.get_by_status.return_value = [extracted]
+
+        # Existing politician found
+        existing_politician = Politician(
+            id=10,
+            name="山田太郎",
+            speaker_id=5,
+            political_party_id=1,
+            district="東京1区",  # Old district
+            position="衆議院議員",
+            profile_page_url="https://example.com/yamada-old",
+            profile_image_url="https://example.com/yamada-old.jpg",
+        )
+        mock_politician_repo.get_by_name_and_party.return_value = existing_politician
+
+        # Mock speaker retrieval
+        existing_speaker = Speaker(id=5, name="山田太郎", is_politician=True)
+        mock_speaker_repo.find_by_name.return_value = existing_speaker
+
+        # Mock politician update
+        updated_politician = Politician(
+            id=10,
+            name="山田太郎",
+            speaker_id=5,
+            political_party_id=1,
+            district="東京2区",  # Updated
+            position="衆議院議員",
+            profile_page_url="https://example.com/yamada-new",  # Updated
+            profile_image_url="https://example.com/yamada-new.jpg",  # Updated
+        )
+        mock_politician_repo.update.return_value = updated_politician
+
+        # Execute
+        result = await use_case.execute(ConvertExtractedPoliticianInputDTO())
+
+        # Assertions
+        assert result.total_processed == 1
+        assert result.converted_count == 1
+        assert result.skipped_count == 0
+        assert result.error_count == 0
+
+        # Verify update was called instead of create
+        mock_politician_repo.create.assert_not_called()
+        mock_politician_repo.update.assert_called_once()
+
+        # Verify the updated values
+        updated_arg = mock_politician_repo.update.call_args[0][0]
+        assert updated_arg.district == "東京2区"
+        assert updated_arg.profile_page_url == "https://example.com/yamada-new"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_mode(
+        self,
+        use_case,
+        mock_extracted_politician_repo,
+        mock_politician_repo,
+        mock_speaker_repo,
+    ):
+        """Test dry run mode doesn't save changes."""
+        # Setup
+        extracted = ExtractedPolitician(
+            id=1,
+            name="山田太郎",
+            party_id=1,
+            district="東京1区",
+            position="衆議院議員",
+            status="approved",
+        )
+
+        mock_extracted_politician_repo.get_by_status.return_value = [extracted]
+        mock_politician_repo.get_by_name_and_party.return_value = None
+
+        # Execute with dry_run=True
+        result = await use_case.execute(
+            ConvertExtractedPoliticianInputDTO(dry_run=True)
+        )
+
+        # Assertions
+        assert result.total_processed == 1
+        assert result.converted_count == 1  # Simulated conversion
+
+        # Verify no actual changes were made
+        mock_speaker_repo.create.assert_not_called()
+        mock_politician_repo.create.assert_not_called()
+        mock_extracted_politician_repo.update_status.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_filter_by_party_id(
+        self,
+        use_case,
+        mock_extracted_politician_repo,
+        mock_politician_repo,
+        mock_speaker_repo,
+    ):
+        """Test filtering by party_id."""
+        # Setup
+        extracted_politicians = [
+            ExtractedPolitician(id=1, name="山田太郎", party_id=1, status="approved"),
+            ExtractedPolitician(id=2, name="鈴木花子", party_id=2, status="approved"),
+            ExtractedPolitician(id=3, name="佐藤一郎", party_id=1, status="approved"),
+        ]
+
+        mock_extracted_politician_repo.get_by_status.return_value = (
+            extracted_politicians
+        )
+
+        # Mock speaker and politician creation for party_id=1 only
+        mock_speaker_repo.find_by_name.return_value = None
+        mock_speaker_repo.create.side_effect = [
+            Speaker(id=1, name="山田太郎", is_politician=True),
+            Speaker(id=3, name="佐藤一郎", is_politician=True),
+        ]
+
+        mock_politician_repo.get_by_name_and_party.return_value = None
+        mock_politician_repo.create.side_effect = [
+            Politician(id=1, name="山田太郎", speaker_id=1, political_party_id=1),
+            Politician(id=3, name="佐藤一郎", speaker_id=3, political_party_id=1),
+        ]
+
+        # Execute with party_id filter
+        result = await use_case.execute(ConvertExtractedPoliticianInputDTO(party_id=1))
+
+        # Assertions
+        assert result.total_processed == 2  # Only party_id=1 politicians
+        assert result.converted_count == 2
+        assert all(p.party_id == 1 for p in result.converted_politicians)
+
+    @pytest.mark.asyncio
+    async def test_batch_size_limit(
+        self,
+        use_case,
+        mock_extracted_politician_repo,
+        mock_politician_repo,
+        mock_speaker_repo,
+    ):
+        """Test batch size limiting."""
+        # Setup - create more politicians than batch size
+        extracted_politicians = [
+            ExtractedPolitician(id=i, name=f"政治家{i}", party_id=1, status="approved")
+            for i in range(1, 6)  # 5 politicians
+        ]
+
+        mock_extracted_politician_repo.get_by_status.return_value = (
+            extracted_politicians
+        )
+
+        # Mock speaker and politician creation for batch_size=3
+        mock_speaker_repo.find_by_name.return_value = None
+        mock_speaker_repo.create.side_effect = [
+            Speaker(id=i, name=f"政治家{i}", is_politician=True) for i in range(1, 4)
+        ]
+
+        mock_politician_repo.get_by_name_and_party.return_value = None
+        mock_politician_repo.create.side_effect = [
+            Politician(id=i, name=f"政治家{i}", speaker_id=i, political_party_id=1)
+            for i in range(1, 4)
+        ]
+
+        # Execute with batch_size=3
+        result = await use_case.execute(
+            ConvertExtractedPoliticianInputDTO(batch_size=3)
+        )
+
+        # Assertions
+        assert result.total_processed == 3  # Limited by batch_size
+        assert result.converted_count == 3
+
+    @pytest.mark.asyncio
+    async def test_handle_conversion_error(
+        self,
+        use_case,
+        mock_extracted_politician_repo,
+        mock_politician_repo,
+        mock_speaker_repo,
+    ):
+        """Test handling errors during conversion."""
+        # Setup
+        extracted_politicians = [
+            ExtractedPolitician(id=1, name="山田太郎", party_id=1, status="approved"),
+            ExtractedPolitician(id=2, name="鈴木花子", party_id=2, status="approved"),
+        ]
+
+        mock_extracted_politician_repo.get_by_status.return_value = (
+            extracted_politicians
+        )
+
+        # First speaker creation succeeds, second fails
+        mock_speaker_repo.find_by_name.return_value = None
+        mock_speaker_repo.create.side_effect = [
+            Speaker(id=1, name="山田太郎", is_politician=True),
+            Exception("Database error"),
+        ]
+
+        mock_politician_repo.get_by_name_and_party.return_value = None
+        mock_politician_repo.create.return_value = Politician(
+            id=1, name="山田太郎", speaker_id=1, political_party_id=1
+        )
+
+        # Execute
+        result = await use_case.execute(ConvertExtractedPoliticianInputDTO())
+
+        # Assertions
+        assert result.total_processed == 2
+        assert result.converted_count == 1  # Only first succeeded
+        assert result.error_count == 1
+        assert "鈴木花子" in result.error_messages[0]


### PR DESCRIPTION
## 概要
レビュー済みのextracted_politiciansレコードをpoliticiansテーブルに変換するユースケースを実装しました。

## 解決したIssue
Fixes #516

## 実装内容

### 1. ConvertExtractedPoliticianUseCase
- approved状態のレコードのみを変換対象
- Speakerの作成/取得 → Politicianの作成/更新 → statusをconvertedに更新
- バッチ処理とdry-runモードをサポート

### 2. DTOクラス
- `ConvertExtractedPoliticianInputDTO`: 入力パラメータ（party_id, batch_size, dry_run）
- `ConvertedPoliticianDTO`: 変換された政治家情報  
- `ConvertExtractedPoliticianOutputDTO`: 変換結果サマリー

### 3. CLIコマンド
```bash
polibase convert-politicians [OPTIONS]
  --party-id: 特定政党のみ対象
  --batch-size: バッチサイズ（デフォルト100）
  --dry-run: 実際の変換なしで結果確認
```

### 4. データベース更新
- migration 028: extracted_politiciansテーブルに'converted'ステータスを追加

### 5. テスト
- 6つのテストケースで正常系・異常系を網羅
- 全テストPASS

## 動作確認

```bash
# Dry-runモード
$ polibase convert-politicians --dry-run --batch-size 3
Total processed: 3
Successfully converted: 3

# 実際の変換
$ polibase convert-politicians --batch-size 3
Successfully converted 3 politicians
✓ テスト議員1 (ID: 249)
✓ テスト議員2 (ID: 250)  
✓ テスト議員3 (ID: 251)
```

## チェックリスト
- [x] コードがプロジェクトの規約に従っている
- [x] ユニットテストを実装し、全てPASS
- [x] 動作確認済み
- [x] ドキュメント更新済み

## アーキテクチャレビュー結果
- Clean Architecture準拠 ✅
- 依存関係ルール遵守 ✅
- 適切なエラーハンドリング ✅
- 包括的なテストカバレッジ ✅

### 今後の改善提案
- トランザクション管理をユースケースレベルで実装
- より具体的な例外型でのエラーハンドリング

🤖 Generated with [Claude Code](https://claude.ai/code)