### PR TITLE
fix: streamlitの政党ページでのAttributeError修正

### DIFF
--- a/src/streamlit/utils/sync_politician_scraper.py
+++ b/src/streamlit/utils/sync_politician_scraper.py
@@ -143,11 +143,8 @@ class SyncPoliticianScraper:
                         district = (
                             f" ({politician.district})" if politician.district else ""
                         )
-                        position = (
-                            f" - {politician.position}" if politician.position else ""
-                        )
                         details_lines.append(
-                            f"  {i}. {status} {politician.name}{district}{position}"
+                            f"  {i}. {status} {politician.name}{district}"
                         )
                     if len(all_politicians) > 30:
                         details_lines.append(f"  ... 他{len(all_politicians) - 30}人")
@@ -166,10 +163,7 @@ class SyncPoliticianScraper:
                         district = (
                             f" ({politician.district})" if politician.district else ""
                         )
-                        position = (
-                            f" - {politician.position}" if politician.position else ""
-                        )
-                        new_details.append(f"  • {politician.name}{district}{position}")
+                        new_details.append(f"  • {politician.name}{district}")
                     if len(new_politicians_list) > 20:
                         new_details.append(
                             f"  ... 他{len(new_politicians_list) - 20}人"
@@ -189,12 +183,7 @@ class SyncPoliticianScraper:
                         district = (
                             f" ({politician.district})" if politician.district else ""
                         )
-                        position = (
-                            f" - {politician.position}" if politician.position else ""
-                        )
-                        updated_details.append(
-                            f"  • {politician.name}{district}{position}"
-                        )
+                        updated_details.append(f"  • {politician.name}{district}")
                     if len(updated_politicians_list) > 20:
                         updated_details.append(
                             f"  ... 他{len(updated_politicians_list) - 20}人"


### PR DESCRIPTION
## 概要
Issue #534で報告されたStreamlitの政党ページにおける`AttributeError`を修正しました。

## 問題の詳細
`ExtractedPoliticianOutputDTO`から`position`属性が削除されたにもかかわらず、
`src/streamlit/utils/sync_politician_scraper.py`内の3箇所で`politician.position`への参照が残っていたため、
政党ページで抽出ボタンを押すと以下のエラーが発生していました：

```
AttributeError: 'ExtractedPoliticianOutputDTO' object has no attribute 'position'
```

## 変更内容
`sync_politician_scraper.py`の以下の3箇所から`position`属性への参照を削除しました：
1. 全政治家リスト表示部分（146-150行目）
2. 新規追加された政治家リスト表示部分（169-172行目）
3. 更新された政治家リスト表示部分（192-196行目）

## 検証
- ✅ ruff format および ruff check: 全てパス
- ✅ pyright: 型チェック成功（エラー0件、既存の警告のみ）
- ✅ pytest: 640テスト成功（1件の統合テストエラーはDB環境の問題で、修正とは無関係）

## 関連Issue
Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)